### PR TITLE
feat(ingestion): FDA 라벨 섹션 청커 (#5)

### DIFF
--- a/src/mediforme_chatbot_rag/ingestion/chunker.py
+++ b/src/mediforme_chatbot_rag/ingestion/chunker.py
@@ -1,0 +1,68 @@
+"""FDA 라벨 섹션 청커.
+
+FdaLabel 을 검색 단위 청크 리스트로 변환한다.
+기본 전략은 섹션 1개 = 청크 1개이며, 너무 긴 섹션은 문장 경계로 분할하고
+너무 짧은 섹션은 스킵한다.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel
+
+from mediforme_chatbot_rag.ingestion.fda_fetcher import FdaLabel
+
+MAX_CHUNK_CHARS = 2000
+MIN_CHUNK_CHARS = 50
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+
+class Chunk(BaseModel):
+    """검색 단위 텍스트 청크."""
+
+    text: str
+    section: str
+    drug_name: str
+    source: str = "fda_label"
+
+
+def chunk_label(label: FdaLabel) -> list[Chunk]:
+    """FdaLabel 의 섹션을 검색 단위 청크 리스트로 변환한다."""
+    chunks: list[Chunk] = []
+    for section, parts in label.sections.items():
+        text = "\n".join(part.strip() for part in parts if part.strip())
+        if len(text) < MIN_CHUNK_CHARS:
+            continue
+        for piece in _split_if_too_long(text, MAX_CHUNK_CHARS):
+            chunks.append(
+                Chunk(
+                    text=piece,
+                    section=section,
+                    drug_name=label.drug_name,
+                )
+            )
+    return chunks
+
+
+def _split_if_too_long(text: str, max_chars: int) -> list[str]:
+    if len(text) <= max_chars:
+        return [text]
+
+    sentences = _SENTENCE_BOUNDARY.split(text)
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+    for sentence in sentences:
+        addition = len(sentence) + (1 if current else 0)
+        if current and current_len + addition > max_chars:
+            chunks.append(" ".join(current))
+            current = [sentence]
+            current_len = len(sentence)
+        else:
+            current.append(sentence)
+            current_len += addition
+    if current:
+        chunks.append(" ".join(current))
+    return chunks

--- a/tests/ingestion/test_chunker.py
+++ b/tests/ingestion/test_chunker.py
@@ -1,0 +1,130 @@
+"""FDA 라벨 청커 단위 테스트."""
+
+from __future__ import annotations
+
+from mediforme_chatbot_rag.ingestion.chunker import (
+    MAX_CHUNK_CHARS,
+    Chunk,
+    chunk_label,
+)
+from mediforme_chatbot_rag.ingestion.fda_fetcher import FdaLabel
+
+
+def _label(sections: dict[str, list[str]], drug_name: str = "TYLENOL") -> FdaLabel:
+    return FdaLabel(
+        drug_name=drug_name,
+        sections=sections,
+        set_id="abcd-1234",
+        effective_time="20240101",
+    )
+
+
+def test_each_section_becomes_one_chunk_when_short_enough() -> None:
+    label = _label(
+        {
+            "indications_and_usage": [
+                "For temporary relief of minor aches and headaches due to colds."
+            ],
+            "contraindications": [
+                "Do not use if you have severe hepatic impairment or alcohol use disorder."
+            ],
+            "warnings": ["Consult a doctor if symptoms persist for more than seven days."],
+        }
+    )
+
+    chunks = chunk_label(label)
+
+    assert len(chunks) == 3
+    assert [c.section for c in chunks] == [
+        "indications_and_usage",
+        "contraindications",
+        "warnings",
+    ]
+    for c in chunks:
+        assert isinstance(c, Chunk)
+        assert c.drug_name == "TYLENOL"
+        assert c.source == "fda_label"
+
+
+def test_short_section_is_skipped() -> None:
+    label = _label(
+        {
+            "tiny": ["None"],
+            "indications_and_usage": [
+                "For temporary relief of minor aches and headaches due to colds and flu."
+            ],
+        }
+    )
+
+    chunks = chunk_label(label)
+
+    sections = [c.section for c in chunks]
+    assert "tiny" not in sections
+    assert "indications_and_usage" in sections
+
+
+def test_long_section_is_split_by_sentence_boundary() -> None:
+    sentence = (
+        "This drug is used for relief of pain and reduction of fever in adults and children. "
+    )
+    long_text = sentence * 40
+
+    label = _label({"warnings": [long_text]})
+
+    chunks = chunk_label(label)
+
+    assert len(chunks) > 1
+    for c in chunks:
+        assert len(c.text) <= MAX_CHUNK_CHARS
+        assert c.section == "warnings"
+
+
+def test_empty_parts_are_filtered_out() -> None:
+    label = _label(
+        {
+            "indications_and_usage": [
+                "",
+                "  ",
+                "For temporary relief of minor aches and headaches due to colds.",
+            ]
+        }
+    )
+
+    chunks = chunk_label(label)
+
+    assert len(chunks) == 1
+    assert "For temporary relief" in chunks[0].text
+    assert "\n" not in chunks[0].text
+
+
+def test_multi_part_section_is_joined_with_newline() -> None:
+    label = _label(
+        {
+            "warnings": [
+                "Consult a doctor if symptoms persist for more than seven days.",
+                "Stop use and ask a doctor if pain or fever gets worse.",
+            ]
+        }
+    )
+
+    chunks = chunk_label(label)
+
+    assert len(chunks) == 1
+    assert "\n" in chunks[0].text
+    assert "Consult a doctor" in chunks[0].text
+    assert "Stop use" in chunks[0].text
+
+
+def test_drug_name_propagates_to_chunks() -> None:
+    label = _label(
+        {
+            "indications_and_usage": [
+                "For temporary relief of minor aches and headaches due to colds."
+            ]
+        },
+        drug_name="ACETAMINOPHEN",
+    )
+
+    chunks = chunk_label(label)
+
+    assert all(c.drug_name == "ACETAMINOPHEN" for c in chunks)

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -347,6 +348,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
@@ -776,6 +778,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 요약
이슈 #5 의 FDA 라벨 섹션 청커를 구현했습니다. Phase C-2 의 두 번째 단계로, FdaLabel 을 검색 단위 청크 리스트로 쪼개는 부분입니다!

## 주요 변경
- Chunk pydantic 모델(text, section, drug_name, source) 과 chunk_label 함수 추가
- 섹션 1개 = 청크 1개 가 기본, MAX_CHUNK_CHARS(2000) 초과 시 문장 경계로 분할
- MIN_CHUNK_CHARS(50) 미만 섹션 스킵
- 다중 part 섹션은 줄바꿈으로 합쳐서 처리
- 청커 단위 테스트 6종 추가
- uv.lock 재생성으로 develop 의 lock/pyproject mismatch 정리 (respx 반영)

## 구현 메모
- **청킹 방식**: fixed-window / overlap / LLM-semantic 대신 라벨이 이미 가진 의미 단위 섹션을 그대로 활용했습니다. 라벨 도메인 특성상 가장 손이 적고 신호도 명확한 1차 전략이라 판단했습니다.
- **문장 분할**: 정규식 기반 단순 분할(\`.?!\` + 공백) 입니다. "e.g." 같은 약어에서 일부 over-split 가능성은 있지만 1차 청커엔 충분하다고 보고, 필요해지면 그때 보강할 생각입니다.
- **메타 분리**: set_id·effective_time 는 청커 출력에 일부러 안 넣었습니다. 청커는 의미 단위 생성, 메타 전파는 저장 레이어에서 FdaLabel 원본과 합치는 쪽이 자연스럽다고 봤습니다.

## 테스트 결과
- pytest 17개 통과 (페처 11 + 청커 6, integration 1 제외)
- mypy src 통과
- ruff check / format --check 통과

Closes #5