### PR TITLE
feat(ingestion): FAISS 인덱스 빌더 (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ LOG_LEVEL=INFO
 EMBEDDING_MODEL_NAME=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
 EMBEDDING_DIMENSIONS=768
 EMBEDDING_BATCH_SIZE=32
+
+# --- FAISS 인덱스 ---
+INDEX_DIR=data/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "openai>=1.30.0",
     "python-dotenv>=1.0.0",
     "sentence-transformers>=3.0",
+    "faiss-cpu>=1.8",
 ]
 
 [project.optional-dependencies]
@@ -59,6 +60,10 @@ python_version = "3.12"
 strict = true
 warn_unused_ignores = true
 warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "faiss"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/src/mediforme_chatbot_rag/core/config.py
+++ b/src/mediforme_chatbot_rag/core/config.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     embedding_dimensions: int = 768
     embedding_batch_size: int = 32
 
+    index_dir: str = "data/index"
+
     default_top_k: int = 5
 
 

--- a/src/mediforme_chatbot_rag/ingestion/index.py
+++ b/src/mediforme_chatbot_rag/ingestion/index.py
@@ -1,0 +1,110 @@
+"""FAISS 인덱스 빌더
+
+- IndexFlatIP + L2 정규화로 코사인 유사도 검색
+- Chunk 메타는 JSON 파일로 별도 저장
+- save / load 로 디스크 영속화
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from mediforme_chatbot_rag.ingestion.chunker import Chunk
+
+INDEX_FILENAME = "index.faiss"
+CHUNKS_FILENAME = "chunks.json"
+
+
+class FaissIndex:
+    """
+    FAISS IndexFlatIP 기반 코사인 유사도 인덱스
+    """
+
+    def __init__(self, dim: int) -> None:
+        import faiss
+
+        self._dim = dim
+        self._index: Any = faiss.IndexFlatIP(dim)
+        self._chunks: list[Chunk] = []
+
+    def __len__(self) -> int:
+        return len(self._chunks)
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def add(self, chunks: list[Chunk], embeddings: list[list[float]]) -> None:
+        if len(chunks) != len(embeddings):
+            raise ValueError(
+                f"chunks 와 embeddings 길이가 다름: {len(chunks)} vs {len(embeddings)}"
+            )
+        if not chunks:
+            return
+
+        vectors = np.asarray(embeddings, dtype=np.float32)
+        if vectors.shape[1] != self._dim:
+            raise ValueError(
+                f"임베딩 차원 불일치: 인덱스 dim={self._dim}, 입력 dim={vectors.shape[1]}"
+            )
+        _normalize_in_place(vectors)
+        self._index.add(vectors)
+        self._chunks.extend(chunks)
+
+    def search(
+        self,
+        query_embedding: list[float],
+        top_k: int,
+    ) -> list[tuple[Chunk, float]]:
+        if not self._chunks or top_k <= 0:
+            return []
+
+        query = np.asarray([query_embedding], dtype=np.float32)
+        if query.shape[1] != self._dim:
+            raise ValueError(
+                f"쿼리 임베딩 차원 불일치: 인덱스 dim={self._dim}, 쿼리 dim={query.shape[1]}"
+            )
+        _normalize_in_place(query)
+
+        k = min(top_k, len(self._chunks))
+        scores, indices = self._index.search(query, k)
+        results: list[tuple[Chunk, float]] = []
+        for score, idx in zip(scores[0], indices[0], strict=True):
+            if idx < 0:
+                continue
+            results.append((self._chunks[int(idx)], float(score)))
+        return results
+
+    def save(self, path: Path) -> None:
+        import faiss
+
+        path.mkdir(parents=True, exist_ok=True)
+        faiss.write_index(self._index, str(path / INDEX_FILENAME))
+        chunks_data = [c.model_dump() for c in self._chunks]
+        (path / CHUNKS_FILENAME).write_text(
+            json.dumps(chunks_data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @classmethod
+    def load(cls, path: Path) -> FaissIndex:
+        import faiss
+
+        loaded_index = faiss.read_index(str(path / INDEX_FILENAME))
+        chunks_data = json.loads((path / CHUNKS_FILENAME).read_text(encoding="utf-8"))
+
+        instance = cls.__new__(cls)
+        instance._dim = int(loaded_index.d)
+        instance._index = loaded_index
+        instance._chunks = [Chunk(**c) for c in chunks_data]
+        return instance
+
+
+def _normalize_in_place(vectors: Any) -> None:
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    vectors /= norms

--- a/tests/ingestion/test_index.py
+++ b/tests/ingestion/test_index.py
@@ -1,0 +1,117 @@
+"""FAISS 인덱스 단위 테스트
+
+- 작은 차원(4) 으로 add → search → save → load 라운드트립 검증
+- 입력 검증(차원·길이 불일치) 케이스 포함
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mediforme_chatbot_rag.ingestion.chunker import Chunk
+from mediforme_chatbot_rag.ingestion.index import FaissIndex
+
+
+def _chunk(text: str, section: str = "warnings", drug_name: str = "TYLENOL") -> Chunk:
+    return Chunk(text=text, section=section, drug_name=drug_name)
+
+
+def test_empty_index_has_zero_length() -> None:
+    index = FaissIndex(dim=4)
+    assert len(index) == 0
+
+
+def test_add_extends_length() -> None:
+    index = FaissIndex(dim=4)
+    chunks = [_chunk("hello"), _chunk("world")]
+    embeddings = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+
+    index.add(chunks, embeddings)
+
+    assert len(index) == 2
+
+
+def test_add_empty_lists_does_nothing() -> None:
+    index = FaissIndex(dim=4)
+    index.add([], [])
+    assert len(index) == 0
+
+
+def test_add_length_mismatch_raises() -> None:
+    index = FaissIndex(dim=4)
+    with pytest.raises(ValueError, match="길이가 다름"):
+        index.add([_chunk("a")], [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]])
+
+
+def test_add_dim_mismatch_raises() -> None:
+    index = FaissIndex(dim=4)
+    with pytest.raises(ValueError, match="차원 불일치"):
+        index.add([_chunk("a")], [[1.0, 0.0]])
+
+
+def test_search_returns_closest_chunk_first() -> None:
+    index = FaissIndex(dim=4)
+    chunks = [_chunk("first"), _chunk("second"), _chunk("third")]
+    embeddings = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+    ]
+    index.add(chunks, embeddings)
+
+    results = index.search([0.9, 0.1, 0.0, 0.0], top_k=2)
+
+    assert len(results) == 2
+    assert results[0][0].text == "first"
+    assert results[0][1] >= results[1][1]
+
+
+def test_search_empty_index_returns_empty() -> None:
+    index = FaissIndex(dim=4)
+    assert index.search([1.0, 0.0, 0.0, 0.0], top_k=5) == []
+
+
+def test_search_top_k_zero_returns_empty() -> None:
+    index = FaissIndex(dim=4)
+    index.add([_chunk("a")], [[1.0, 0.0, 0.0, 0.0]])
+    assert index.search([1.0, 0.0, 0.0, 0.0], top_k=0) == []
+
+
+def test_search_dim_mismatch_raises() -> None:
+    index = FaissIndex(dim=4)
+    index.add([_chunk("a")], [[1.0, 0.0, 0.0, 0.0]])
+
+    with pytest.raises(ValueError, match="차원 불일치"):
+        index.search([1.0, 0.0], top_k=1)
+
+
+def test_save_load_roundtrip(tmp_path: Path) -> None:
+    index = FaissIndex(dim=4)
+    chunks = [
+        _chunk("first", section="indications"),
+        _chunk("second", section="warnings"),
+    ]
+    embeddings = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+    index.add(chunks, embeddings)
+    index.save(tmp_path)
+
+    loaded = FaissIndex.load(tmp_path)
+
+    assert len(loaded) == 2
+    assert loaded.dim == 4
+
+    results = loaded.search([1.0, 0.0, 0.0, 0.0], top_k=1)
+    assert results[0][0].text == "first"
+    assert results[0][0].section == "indications"
+    assert results[0][0].drug_name == "TYLENOL"
+
+
+def test_save_creates_index_and_chunks_files(tmp_path: Path) -> None:
+    index = FaissIndex(dim=4)
+    index.add([_chunk("a")], [[1.0, 0.0, 0.0, 0.0]])
+    index.save(tmp_path)
+
+    assert (tmp_path / "index.faiss").exists()
+    assert (tmp_path / "chunks.json").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,29 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cpu"
+version = "1.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/4a/97150aa1582fb9c2bca95bd8fc37f27d3b470acec6f0a6833844b21e4b40/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_x86_64.whl", hash = "sha256:c8d097884521e1ecaea6467aeebbf1aa56ee4a36350b48b2ca6b39366565c317", size = 7896434, upload-time = "2025-12-24T10:27:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d0/0940575f059591ca31b63a881058adb16a387020af1709dcb7669460115c/faiss_cpu-1.13.2-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ee330a284042c2480f2e90450a10378fd95655d62220159b1408f59ee83ebf1", size = 11485825, upload-time = "2025-12-24T10:27:05.681Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e1/a5acac02aa593809f0123539afe7b4aff61d1db149e7093239888c9053e1/faiss_cpu-1.13.2-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ab88ee287c25a119213153d033f7dd64c3ccec466ace267395872f554b648cd7", size = 23845772, upload-time = "2025-12-24T10:27:08.194Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/7b/49dcaf354834ec457e85ca769d50bc9b5f3003fab7c94a9dcf08cf742793/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:85511129b34f890d19c98b82a0cd5ffb27d89d1cec2ee41d2621ee9f9ef8cf3f", size = 13477567, upload-time = "2025-12-24T10:27:10.822Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6b/12bb4037921c38bb2c0b4cfc213ca7e04bbbebbfea89b0b5746248ce446e/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b32eb4065bac352b52a9f5ae07223567fab0a976c7d05017c01c45a1c24264f", size = 25102239, upload-time = "2025-12-24T10:27:13.476Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/35ed875423200c17bdd594ce921abfc1812ddd21e09355290b9a94e170ab/faiss_cpu-1.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:b82c01d30430dd7b1fa442001b9099735d1a82f6bb72033acdc9206d5ac66a64", size = 18890300, upload-time = "2025-12-24T10:27:24.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3a/bbdf5deaf6feb34b46b469c0a0acd40216c3d3c6ecf5aeb71d56b8a650e3/faiss_cpu-1.13.2-cp312-cp312-win_arm64.whl", hash = "sha256:2c4f696ae76e7c97cbc12311db83aaf1e7f4f7be06a3ffea7e5b0e8ec1fd805b", size = 8553157, upload-time = "2025-12-24T10:27:26.38Z" },
+    { url = "https://files.pythonhosted.org/packages/60/4b/903d85bf3a8264d49964ec799e45c7ffc91098606b8bc9ef2c904c1a56cb/faiss_cpu-1.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:cb4b5ee184816a4b099162ac93c0d7f0033d81a88e7c1291d0a9cc41ec348984", size = 18891330, upload-time = "2025-12-24T10:27:28.806Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/52/5d10642da628f63544aab27e48416be4a7ea25c6b81d8bd65016d8538b00/faiss_cpu-1.13.2-cp313-cp313-win_arm64.whl", hash = "sha256:1243967eeb2298791ff7f3683a4abd2100d7e6ec7542ca05c3b75d47a7f621e5", size = 8553088, upload-time = "2025-12-24T10:27:31.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b1/daaab8046f56c60079648bd83774f61b283b59a9930a2f60790ee4cdedfe/faiss_cpu-1.13.2-cp314-cp314-win_amd64.whl", hash = "sha256:c8b645e7d56591aa35dc75415bb53a62e4a494dba010e16f4b67daeffd830bd7", size = 18892621, upload-time = "2025-12-24T10:27:33.923Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6f/5eaf3e249c636e616ebb52e369a4a2f1d32b1caf9a611b4f917b3dd21423/faiss_cpu-1.13.2-cp314-cp314-win_arm64.whl", hash = "sha256:8113a2a80b59fe5653cf66f5c0f18be0a691825601a52a614c30beb1fca9bc7c", size = 8556374, upload-time = "2025-12-24T10:27:36.653Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -557,6 +580,7 @@ name = "mediforme-chatbot-rag"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "faiss-cpu" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "openai" },
@@ -581,6 +605,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "faiss-cpu", specifier = ">=1.8" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },


### PR DESCRIPTION
## 요약
이슈 #9 의 FAISS 인덱스 빌더를 구현했습니다. 임베더가 만든 768차원 벡터를 청크 메타와 함께 인덱스에 넣고, 디스크로 영속화·재로드까지 가능하게 만들었습니다. 다음 이슈에서 /retrieve 가 이 인덱스를 로드해 검색 결과를 그대로 RetrievedChunk 로 돌려줄 예정입니다.

## 주요 변경
- FaissIndex 클래스 — add / search / save / load + dim / __len__
- IndexFlatIP + L2 정규화로 코사인 유사도 검색 (정확도 100%)
- 청크 메타는 chunks.json 으로 별도 저장 (FAISS 는 벡터만 다루므로)
- save / load 는 디렉터리 단위 — index.faiss + chunks.json 두 파일
- faiss-cpu>=1.8 의존성 추가
- Settings 에 index_dir 추가 (기본 data/index)
- mypy override 로 faiss 타입 스텁 부재 경고 무시 (faiss 는 stub 미제공 라이브러리)

## 구현 메모
- **인덱스 종류**: 데이터 규모(수만~수십만 청크)가 ANN 까지 갈 정도가 아니라 IndexFlatIP + 정규화로 단순하게 갔습니다. 정확도 100% 보장에 구현·검증이 단순하고, 규모가 커지면 IVFFlat 으로 갈아끼우면 됩니다.
- **메타 저장 방식**: pickle 은 보안·호환성 측면에서 부담이 있어 JSON 으로 갔습니다. Chunk 가 pydantic 모델이라 model_dump → 그대로 직렬화 가능하고, 디버깅 시 사람이 읽을 수 있다는 게 장점입니다.
- **embedder 와 분리**: 인덱스는 임베딩을 받는 입장으로만 두었습니다. add 가 embeddings 를 받아서 자체적으로 정규화·저장만 하고, 임베딩 자체는 호출자(나중엔 ingest CLI) 가 책임집니다.
- **lazy faiss import**: faiss 는 SWIG 바인딩이라 임포트 비용이 있어, 메서드 내부에서 import 했습니다. 모듈 import 시점에 부담이 안 가도록.

## 테스트 결과
- pytest 34개 통과 (페처 11 + 청커 6 + 임베더 6 + index 11), integration 2개 제외
- mypy src 통과 (faiss 는 untyped 라이브러리라 override 추가)
- ruff check / format --check 통과

Closes #9