### PR TITLE
feat(ingestion): MFDS 의약품 첨부문서 페처 (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ OPENAI_API_KEY=
 OPENFDA_API_KEY=
 OPENFDA_BASE_URL=https://api.fda.gov
 
+# 식약처 의약품안전나라 (e약은요 endpoint)
+MFDS_API_KEY=
+MFDS_BASE_URL=https://apis.data.go.kr/1471000/DrugPrdtPrmsnInfoService06
+
 # --- 데이터베이스 (pgvector) ---
 DATABASE_URL=postgresql://mediforme:mediforme@localhost:5432/mediforme_rag
 

--- a/src/mediforme_chatbot_rag/core/config.py
+++ b/src/mediforme_chatbot_rag/core/config.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     openfda_api_key: str = ""
     openfda_base_url: str = "https://api.fda.gov"
 
+    mfds_api_key: str = ""
+    mfds_base_url: str = "https://apis.data.go.kr/1471000/DrugPrdtPrmsnInfoService06"
+
     embedding_model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
     embedding_dimensions: int = 768
     embedding_batch_size: int = 32

--- a/src/mediforme_chatbot_rag/ingestion/chunker.py
+++ b/src/mediforme_chatbot_rag/ingestion/chunker.py
@@ -1,17 +1,16 @@
-"""FDA 라벨 섹션 청커.
+"""FDA 라벨 섹션 청커
 
-FdaLabel 을 검색 단위 청크 리스트로 변환한다.
+FdaLabel 을 검색 단위 청크 리스트로 변환한다
 기본 전략은 섹션 1개 = 청크 1개이며, 너무 긴 섹션은 문장 경계로 분할하고
-너무 짧은 섹션은 스킵한다.
+너무 짧은 섹션은 스킵
 """
 
 from __future__ import annotations
 
 import re
+from typing import Protocol
 
 from pydantic import BaseModel
-
-from mediforme_chatbot_rag.ingestion.fda_fetcher import FdaLabel
 
 MAX_CHUNK_CHARS = 2000
 MIN_CHUNK_CHARS = 50
@@ -19,8 +18,19 @@ MIN_CHUNK_CHARS = 50
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
 
 
+class _LabelLike(Protocol):
+    """
+    FdaLabel / MfdsLabel 처럼 drug_name 과 sections 를 가진 라벨 구조
+    """
+
+    drug_name: str
+    sections: dict[str, list[str]]
+
+
 class Chunk(BaseModel):
-    """검색 단위 텍스트 청크."""
+    """
+    검색 단위 텍스트 청크
+    """
 
     text: str
     section: str
@@ -28,8 +38,12 @@ class Chunk(BaseModel):
     source: str = "fda_label"
 
 
-def chunk_label(label: FdaLabel) -> list[Chunk]:
-    """FdaLabel 의 섹션을 검색 단위 청크 리스트로 변환한다."""
+def chunk_label(label: _LabelLike, *, source: str = "fda_label") -> list[Chunk]:
+    """
+    라벨의 섹션을 검색 단위 청크 리스트로 변환
+
+    - source 는 청크의 출처 식별자 (예: fda_label / mfds_label)
+    """
     chunks: list[Chunk] = []
     for section, parts in label.sections.items():
         text = "\n".join(part.strip() for part in parts if part.strip())
@@ -41,6 +55,7 @@ def chunk_label(label: FdaLabel) -> list[Chunk]:
                     text=piece,
                     section=section,
                     drug_name=label.drug_name,
+                    source=source,
                 )
             )
     return chunks

--- a/src/mediforme_chatbot_rag/ingestion/mfds_fetcher.py
+++ b/src/mediforme_chatbot_rag/ingestion/mfds_fetcher.py
@@ -1,0 +1,144 @@
+"""MFDS 의약품 첨부문서 페처
+
+- 식약처 의약품안전나라 e약은요 API (getDrugPrdtPermitDtlInq03) 호출
+- MfdsLabel 모델로 정규화 (sections 는 효능효과 / 용법용량 / 주의사항 / 부작용 등)
+- 네트워크 계층만 담당하며 청킹·임베딩은 후속 모듈에서 수행
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from mediforme_chatbot_rag.core.config import get_settings
+
+_ENDPOINT = "getDrugPrdtPermitDtlInq03"
+_MAX_RETRIES = 3
+_BACKOFF_BASE_SECONDS = 1.0
+_REQUEST_TIMEOUT_SECONDS = 10.0
+
+# e약은요 응답의 한글 친화 필드 → 한국어 섹션 키 매핑
+_SECTION_FIELDS: dict[str, str] = {
+    "efcyQesitm": "효능효과",
+    "useMethodQesitm": "용법용량",
+    "atpnWarnQesitm": "경고",
+    "atpnQesitm": "사용상의 주의사항",
+    "intrcQesitm": "상호작용",
+    "seQesitm": "부작용",
+    "depositMethodQesitm": "저장방법",
+}
+
+
+class MfdsLabel(BaseModel):
+    """
+    MFDS 의약품 첨부문서 1건의 정규화된 표현
+    """
+
+    drug_name: str
+    sections: dict[str, list[str]] = Field(default_factory=dict)
+    item_seq: str
+    permit_date: str = ""
+
+
+class MfdsFetchError(Exception):
+    """
+    MFDS API 호출 실패
+    """
+
+
+async def fetch_label(
+    query: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> MfdsLabel:
+    """
+    제품명(itemName) 으로 MFDS 의약품 첨부문서 1건 가져오기
+    """
+    settings = get_settings()
+    if not settings.mfds_api_key:
+        raise MfdsFetchError("MFDS_API_KEY 가 설정되지 않음")
+
+    params: dict[str, Any] = {
+        "serviceKey": settings.mfds_api_key,
+        "itemName": query,
+        "type": "json",
+        "numOfRows": 1,
+        "pageNo": 1,
+    }
+
+    url = f"{settings.mfds_base_url}/{_ENDPOINT}"
+
+    if client is None:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as owned:
+            response = await _get_with_retry(owned, url, params)
+    else:
+        response = await _get_with_retry(client, url, params)
+
+    payload = response.json()
+    items = _extract_items(payload)
+    if not items:
+        raise MfdsFetchError(f"MFDS 에 '{query}' 첨부문서가 없음")
+
+    return _to_label(items[0])
+
+
+async def _get_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    params: dict[str, Any],
+) -> httpx.Response:
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            response = await client.get(url, params=params)
+        except httpx.HTTPError as exc:
+            if attempt < _MAX_RETRIES:
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2**attempt))
+                continue
+            raise MfdsFetchError(f"MFDS 호출 실패: {exc}") from exc
+
+        status = response.status_code
+        if status == 429 or 500 <= status < 600:
+            if attempt < _MAX_RETRIES:
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2**attempt))
+                continue
+            raise MfdsFetchError(f"MFDS 재시도 초과: status={status}")
+
+        response.raise_for_status()
+        return response
+
+    raise MfdsFetchError("MFDS 페처가 예상치 못한 상태로 종료됨")
+
+
+def _extract_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    # 공공데이터포털 응답이 {response: {body: ...}} 또는 {body: ...} 형태로 옴
+    body = payload.get("body")
+    if body is None:
+        body = (payload.get("response") or {}).get("body") or {}
+
+    raw_items = body.get("items") or []
+    if isinstance(raw_items, dict):
+        # items 가 단일 객체로 올 때 (단건 응답 일부 케이스)
+        raw_items = [raw_items]
+    return [item for item in raw_items if isinstance(item, dict)]
+
+
+def _to_label(item: dict[str, Any]) -> MfdsLabel:
+    drug_name = item.get("itemName") or ""
+    if not drug_name:
+        raise MfdsFetchError("응답 itemName 없음")
+
+    sections: dict[str, list[str]] = {}
+    for field, korean_key in _SECTION_FIELDS.items():
+        value = item.get(field)
+        if isinstance(value, str) and value.strip():
+            sections[korean_key] = [value]
+
+    return MfdsLabel(
+        drug_name=drug_name,
+        sections=sections,
+        item_seq=str(item.get("itemSeq") or ""),
+        permit_date=str(item.get("permitDate") or item.get("openDe") or ""),
+    )

--- a/tests/ingestion/test_chunker.py
+++ b/tests/ingestion/test_chunker.py
@@ -115,6 +115,22 @@ def test_multi_part_section_is_joined_with_newline() -> None:
     assert "Stop use" in chunks[0].text
 
 
+def test_source_parameter_overrides_default() -> None:
+    label = _label({"warnings": ["Consult a doctor if symptoms persist for more than seven days."]})
+
+    chunks = chunk_label(label, source="mfds_label")
+
+    assert all(c.source == "mfds_label" for c in chunks)
+
+
+def test_default_source_is_fda_label() -> None:
+    label = _label({"warnings": ["Consult a doctor if symptoms persist for more than seven days."]})
+
+    chunks = chunk_label(label)
+
+    assert all(c.source == "fda_label" for c in chunks)
+
+
 def test_drug_name_propagates_to_chunks() -> None:
     label = _label(
         {

--- a/tests/ingestion/test_mfds_fetcher.py
+++ b/tests/ingestion/test_mfds_fetcher.py
@@ -1,0 +1,172 @@
+"""MFDS 페처 단위 테스트
+
+- e약은요 응답 정상/에러 경로와 응답 wrapper 두 형식 모두 검증
+- 실 MFDS 호출은 @pytest.mark.integration 마커로 분리
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from mediforme_chatbot_rag.core import config
+from mediforme_chatbot_rag.ingestion.mfds_fetcher import (
+    MfdsFetchError,
+    MfdsLabel,
+    fetch_label,
+)
+
+_BASE = "https://apis.data.go.kr/1471000/DrugPrdtPrmsnInfoService06/getDrugPrdtPermitDtlInq03"
+
+
+def _label_payload(item_overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "itemName": "타이레놀정500밀리그람",
+        "itemSeq": "199101247",
+        "entpName": "한국얀센(주)",
+        "efcyQesitm": "이 약은 해열, 진통, 두통에 사용합니다.",
+        "useMethodQesitm": "성인은 1회 1정씩, 1일 3-4회 복용합니다.",
+        "atpnWarnQesitm": "심한 간장애 환자는 사용하지 마십시오.",
+        "atpnQesitm": "다른 의약품과 동시 복용시 주의하십시오.",
+        "intrcQesitm": "와파린과 병용시 출혈 위험이 증가할 수 있습니다.",
+        "seQesitm": "드물게 발진, 메스꺼움이 나타날 수 있습니다.",
+        "depositMethodQesitm": "직사광선을 피해 보관하십시오.",
+    }
+    if item_overrides:
+        item.update(item_overrides)
+    return {
+        "header": {"resultCode": "00", "resultMsg": "NORMAL SERVICE."},
+        "body": {
+            "pageNo": 1,
+            "totalCount": 1,
+            "numOfRows": 10,
+            "items": [item],
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MFDS_API_KEY", "test-mfds-key")
+    config.get_settings.cache_clear()
+
+
+@pytest.fixture
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mediforme_chatbot_rag.ingestion import mfds_fetcher as mod
+
+    async def _skip(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _skip)
+
+
+async def test_fetch_label_happy_path(respx_mock: respx.Router) -> None:
+    respx_mock.get(_BASE).mock(return_value=httpx.Response(200, json=_label_payload()))
+
+    label = await fetch_label("타이레놀정500밀리그람")
+
+    assert isinstance(label, MfdsLabel)
+    assert label.drug_name == "타이레놀정500밀리그람"
+    assert label.item_seq == "199101247"
+    assert "효능효과" in label.sections
+    assert "용법용량" in label.sections
+    assert "부작용" in label.sections
+    assert label.sections["효능효과"] == ["이 약은 해열, 진통, 두통에 사용합니다."]
+
+
+async def test_fetch_label_handles_response_wrapper(respx_mock: respx.Router) -> None:
+    payload = {"response": _label_payload()}
+    respx_mock.get(_BASE).mock(return_value=httpx.Response(200, json=payload))
+
+    label = await fetch_label("타이레놀")
+
+    assert label.drug_name == "타이레놀정500밀리그람"
+
+
+async def test_fetch_label_no_items_raises(respx_mock: respx.Router) -> None:
+    payload = {"header": {}, "body": {"items": []}}
+    respx_mock.get(_BASE).mock(return_value=httpx.Response(200, json=payload))
+
+    with pytest.raises(MfdsFetchError, match="없음"):
+        await fetch_label("존재하지않는약")
+
+
+async def test_fetch_label_missing_item_name_raises(respx_mock: respx.Router) -> None:
+    payload = _label_payload(item_overrides={"itemName": ""})
+    respx_mock.get(_BASE).mock(return_value=httpx.Response(200, json=payload))
+
+    with pytest.raises(MfdsFetchError, match="itemName"):
+        await fetch_label("test")
+
+
+async def test_fetch_label_without_api_key_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MFDS_API_KEY", "")
+    config.get_settings.cache_clear()
+
+    with pytest.raises(MfdsFetchError, match="MFDS_API_KEY"):
+        await fetch_label("test")
+
+
+async def test_fetch_label_retries_on_429_then_succeeds(
+    respx_mock: respx.Router,
+    _no_sleep: None,
+) -> None:
+    route = respx_mock.get(_BASE).mock(
+        side_effect=[
+            httpx.Response(429),
+            httpx.Response(429),
+            httpx.Response(200, json=_label_payload()),
+        ]
+    )
+
+    label = await fetch_label("타이레놀")
+
+    assert route.call_count == 3
+    assert label.drug_name == "타이레놀정500밀리그람"
+
+
+async def test_fetch_label_retries_exhausted_on_5xx(
+    respx_mock: respx.Router,
+    _no_sleep: None,
+) -> None:
+    respx_mock.get(_BASE).mock(return_value=httpx.Response(500))
+
+    with pytest.raises(MfdsFetchError, match="재시도 초과"):
+        await fetch_label("타이레놀")
+
+
+async def test_fetch_label_passes_service_key_in_params(respx_mock: respx.Router) -> None:
+    route = respx_mock.get(_BASE).mock(return_value=httpx.Response(200, json=_label_payload()))
+
+    await fetch_label("타이레놀")
+
+    assert "serviceKey=test-mfds-key" in str(route.calls.last.request.url)
+
+
+async def test_fetch_label_skips_blank_section_fields(respx_mock: respx.Router) -> None:
+    payload = _label_payload(item_overrides={"intrcQesitm": "", "seQesitm": "   "})
+    respx_mock.get(_BASE).mock(return_value=httpx.Response(200, json=payload))
+
+    label = await fetch_label("타이레놀")
+
+    assert "상호작용" not in label.sections
+    assert "부작용" not in label.sections
+    assert "효능효과" in label.sections
+
+
+@pytest.mark.integration
+async def test_fetch_label_real_mfds() -> None:
+    """
+    실 MFDS 호출
+
+    - pytest -m integration + 실제 MFDS_API_KEY 환경변수 필요
+    """
+    label = await fetch_label("타이레놀")
+    assert label.drug_name
+    assert label.sections


### PR DESCRIPTION
## 요약
이슈 #13 의 MFDS 의약품 첨부문서 페처를 추가했습니다. README 와 backend_medi 양쪽에서 한국 약 데이터를 전제로 두고 있었는데 RAG 쪽엔 빠져 있던 부분이라, 식약처 의약품안전나라 e약은요 API 를 호출하는 페처를 붙여서 한국 약도 인덱싱할 수 있게 합니다.

## 주요 변경
- MfdsLabel 모델 + fetch_label — itemName 으로 첨부문서 1건 fetch
- 한글 친화 필드(efcyQesitm 등) 를 한국어 섹션 키(효능효과 / 용법용량 / 경고 / 사용상의 주의사항 / 상호작용 / 부작용 / 저장방법) 로 매핑
- 응답 wrapper 두 형식(body 직접 / response.body 중첩) 모두 방어적으로 처리
- 429 / 5xx exponential backoff 3회 (FDA 페처와 동일 패턴)
- MFDS_API_KEY / MFDS_BASE_URL 환경변수 + Settings 추가
- chunker 의 chunk_label 이 _LabelLike Protocol + source 인자를 받도록 리팩터 (FdaLabel·MfdsLabel 둘 다 받게)

## 구현 메모
- **endpoint 선택 — e약은요(getDrugPrdtPermitDtlInq03)**: 의약품안전나라 endpoint 가 여러 개인데 e약은요는 한글 친화 필드명 + 환자용 평이한 표현 + 응답 본문이 그대로 텍스트라 챗봇 ground truth 로 가장 적합합니다. 전체 의약품(전문약 포함) 의 XML 본문을 다루는 endpoint 는 후속 이슈로 분리할 생각입니다.
- **API 키 공유**: backend_medi 와 동일한 공공데이터포털 키를 그대로 가져다 쓰는 전제로 갔습니다. RAG 의 ingest 호출량은 backend_medi 검색 호출량 대비 일회성·소량이라 쿼터 압박이 없을 것 같습니다. 정석은 분리지만 1차 운영엔 공유로 충분합니다.
- **chunker source 인자**: 기존 Chunk.source 가 "fda_label" 하드코딩이었는데, source 파라미터를 받게 바꿨습니다. 청커는 라벨이 FdaLabel 이든 MfdsLabel 이든 신경 쓰지 않고 (Protocol 로 추상화) 소스 식별자만 명시적으로 받습니다. 결국 ingest CLI 에서 페처별로 source 를 정해 넘기게 됩니다.
- **응답 wrapper**: 공공데이터포털 API 가 같은 endpoint 라도 환경에 따라 {body:..} / {response:{body:..}} 두 형식이 섞여 있다는 보고가 있어 둘 다 처리하도록 했습니다.

## 테스트 결과
- pytest 55개 통과 (MFDS 9 + 청커 source 2 + 기존 44), integration 3 제외
- mypy src 통과
- ruff check / format --check 통과

Closes #13