### PR TITLE
fix(ingestion): MFDS 페처 endpoint 수정 (#17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ OPENFDA_BASE_URL=https://api.fda.gov
 
 # 식약처 의약품안전나라 (e약은요 endpoint)
 MFDS_API_KEY=
-MFDS_BASE_URL=https://apis.data.go.kr/1471000/DrugPrdtPrmsnInfoService06
+MFDS_BASE_URL=https://apis.data.go.kr/1471000/DrbEasyDrugInfoService
 
 # --- 데이터베이스 (pgvector) ---
 DATABASE_URL=postgresql://mediforme:mediforme@localhost:5432/mediforme_rag

--- a/src/mediforme_chatbot_rag/core/config.py
+++ b/src/mediforme_chatbot_rag/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     openfda_base_url: str = "https://api.fda.gov"
 
     mfds_api_key: str = ""
-    mfds_base_url: str = "https://apis.data.go.kr/1471000/DrugPrdtPrmsnInfoService06"
+    mfds_base_url: str = "https://apis.data.go.kr/1471000/DrbEasyDrugInfoService"
 
     embedding_model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
     embedding_dimensions: int = 768

--- a/src/mediforme_chatbot_rag/ingestion/mfds_fetcher.py
+++ b/src/mediforme_chatbot_rag/ingestion/mfds_fetcher.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 
 from mediforme_chatbot_rag.core.config import get_settings
 
-_ENDPOINT = "getDrugPrdtPermitDtlInq03"
+_ENDPOINT = "getDrbEasyDrugList"
 _MAX_RETRIES = 3
 _BACKOFF_BASE_SECONDS = 1.0
 _REQUEST_TIMEOUT_SECONDS = 10.0

--- a/tests/ingestion/test_mfds_fetcher.py
+++ b/tests/ingestion/test_mfds_fetcher.py
@@ -19,7 +19,7 @@ from mediforme_chatbot_rag.ingestion.mfds_fetcher import (
     fetch_label,
 )
 
-_BASE = "https://apis.data.go.kr/1471000/DrugPrdtPrmsnInfoService06/getDrugPrdtPermitDtlInq03"
+_BASE = "https://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList"
 
 
 def _label_payload(item_overrides: dict[str, Any] | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## 요약
이슈 #17 의 MFDS 404 버그를 고쳤습니다. 처음에 잡은 endpoint(\`DrugPrdtPrmsnInfoService06/getDrugPrdtPermitDtlInq03\`) 는 의약품제품허가정보 서비스 쪽이라 e약은요 필드(efcyQesitm 등)가 안 오는 자리였습니다. e약은요 정통 endpoint 로 갈아끼워서 정상 응답이 오도록 수정했습니다.

## 주요 변경
- mfds_base_url 디폴트: \`DrugPrdtPrmsnInfoService06\` → \`DrbEasyDrugInfoService\`
- _ENDPOINT: \`getDrugPrdtPermitDtlInq03\` → \`getDrbEasyDrugList\` (e약은요 정통 operation)
- 단위 테스트 _BASE URL 동기화
- .env.example 도 같이 갱신

## 구현 메모
- **backend_medi 의 MfdsMedicineClient 도 비슷하게 잘못 호출하고 있는 정황**: \`serviceUrl + "?serviceKey=..."\` 처럼 operation 없이 base URL 에 바로 query string 을 붙여 호출하는데, 실제로 이걸 그대로 보내면 500 이 납니다. RAG 가 \`getDrbEasyDrugList\` 를 명시해서 안전하게 가는 쪽으로 잡았습니다. backend_medi 쪽도 동일한 수정이 필요해 별도 레포 작업 이후 진행하려 합니다.
- **검증**: 실제 MFDS API 에 "타이레놀" 으로 호출해서 6개 섹션(효능효과 / 용법용량 / 경고 / 사용상의 주의사항 / 상호작용 / 부작용 / 저장방법 중 텍스트 있는 6개) 청크가 정상적으로 들어오는 것까지 확인했습니다.

## 테스트 결과
- pytest 64개 통과
- 실 MFDS 호출 1건 (타이레놀) → 6 chunks 정상 수집 + 인덱스 저장
- mypy / ruff 통과

Closes #17