### PR TITLE
feat(eval): 평가 지표 분할 + drug_id 필터 비교 (#21)

### DIFF
--- a/data/eval/queries.yaml
+++ b/data/eval/queries.yaml
@@ -7,6 +7,7 @@
 #   category: pain | allergy | gi | chronic | new | kor_otc | psych | antibiotic | anticoagulant
 #   difficulty: easy | medium | hard
 #   expected_drug_names: list[str] — drug_name 에 substring 매칭 (case-insensitive)
+#   expected_drug_id: str (선택) — drug_id 필터 모드(--use-drug-id-filter)에서 사용
 #   expected_sections: list[str] (선택) — section 에 substring 매칭
 
 # === 한국어 15 ===
@@ -16,6 +17,7 @@
   category: pain
   difficulty: easy
   expected_drug_names: [타이레놀]
+  expected_drug_id: 타이레놀
 
 - id: ko-pain-002
   query: 이부프로펜 부작용
@@ -23,6 +25,7 @@
   category: pain
   difficulty: easy
   expected_drug_names: [부루펜, ibuprofen]
+  expected_drug_id: ibuprofen
 
 - id: ko-pain-003
   query: 술 먹고 진통제 먹어도 돼?
@@ -44,6 +47,7 @@
   category: allergy
   difficulty: easy
   expected_drug_names: [지르텍, cetirizine]
+  expected_drug_id: 지르텍
 
 - id: ko-allergy-002
   query: 콧물 흐를 때 먹는 알레르기 약
@@ -58,6 +62,7 @@
   category: gi
   difficulty: easy
   expected_drug_names: [까스활명수]
+  expected_drug_id: 까스활명수
 
 - id: ko-gi-002
   query: 위장약과 진통제 같이 먹어도 되나
@@ -79,6 +84,7 @@
   category: chronic
   difficulty: easy
   expected_drug_names: [metformin]
+  expected_drug_id: metformin
 
 - id: ko-new-001
   query: 위고비 부작용
@@ -86,6 +92,7 @@
   category: new
   difficulty: easy
   expected_drug_names: [wegovy]
+  expected_drug_id: wegovy
 
 - id: ko-kor-otc-001
   query: 게보린 성분이 뭐야
@@ -93,6 +100,7 @@
   category: kor_otc
   difficulty: easy
   expected_drug_names: [게보린]
+  expected_drug_id: 게보린
 
 - id: ko-kor-otc-002
   query: 판콜에이 종합감기약
@@ -100,6 +108,7 @@
   category: kor_otc
   difficulty: easy
   expected_drug_names: [판콜에이]
+  expected_drug_id: 판콜에이
 
 - id: ko-psych-001
   query: 항우울제 부작용
@@ -114,6 +123,7 @@
   category: antibiotic
   difficulty: medium
   expected_drug_names: [amoxicillin]
+  expected_drug_id: amoxicillin
 
 # === 영어 15 ===
 - id: en-pain-001
@@ -122,6 +132,7 @@
   category: pain
   difficulty: easy
   expected_drug_names: [acetaminophen, tylenol, pain reliever]
+  expected_drug_id: acetaminophen
   expected_sections: [warnings]
 
 - id: en-pain-002
@@ -130,6 +141,7 @@
   category: pain
   difficulty: medium
   expected_drug_names: [ibuprofen]
+  expected_drug_id: ibuprofen
 
 - id: en-pain-003
   query: naproxen stomach bleeding
@@ -137,6 +149,7 @@
   category: pain
   difficulty: medium
   expected_drug_names: [naproxen]
+  expected_drug_id: naproxen
 
 - id: en-allergy-001
   query: cetirizine drowsiness
@@ -144,6 +157,7 @@
   category: allergy
   difficulty: easy
   expected_drug_names: [cetirizine, zyrtec]
+  expected_drug_id: cetirizine
 
 - id: en-allergy-002
   query: loratadine vs fexofenadine
@@ -158,6 +172,7 @@
   category: gi
   difficulty: medium
   expected_drug_names: [omeprazole, prilosec]
+  expected_drug_id: omeprazole
 
 - id: en-gi-002
   query: famotidine acid reflux
@@ -165,6 +180,7 @@
   category: gi
   difficulty: easy
   expected_drug_names: [famotidine, pepcid]
+  expected_drug_id: famotidine
 
 - id: en-chronic-001
   query: atorvastatin muscle pain
@@ -172,6 +188,7 @@
   category: chronic
   difficulty: easy
   expected_drug_names: [atorvastatin, lipitor]
+  expected_drug_id: atorvastatin
 
 - id: en-chronic-002
   query: metformin lactic acidosis
@@ -179,6 +196,7 @@
   category: chronic
   difficulty: medium
   expected_drug_names: [metformin, glucophage]
+  expected_drug_id: metformin
 
 - id: en-chronic-003
   query: amlodipine swelling side effect
@@ -186,6 +204,7 @@
   category: chronic
   difficulty: easy
   expected_drug_names: [amlodipine, norvasc]
+  expected_drug_id: amlodipine
 
 - id: en-new-001
   query: ozempic weight loss side effects
@@ -193,6 +212,7 @@
   category: new
   difficulty: easy
   expected_drug_names: [ozempic, semaglutide]
+  expected_drug_id: ozempic
 
 - id: en-new-002
   query: wegovy contraindications
@@ -200,6 +220,7 @@
   category: new
   difficulty: easy
   expected_drug_names: [wegovy, semaglutide]
+  expected_drug_id: wegovy
   expected_sections: [contraindications]
 
 - id: en-psych-001
@@ -208,6 +229,7 @@
   category: psych
   difficulty: medium
   expected_drug_names: [sertraline, zoloft]
+  expected_drug_id: sertraline
 
 - id: en-antibiotic-001
   query: amoxicillin allergic reaction
@@ -215,6 +237,7 @@
   category: antibiotic
   difficulty: easy
   expected_drug_names: [amoxicillin]
+  expected_drug_id: amoxicillin
 
 - id: en-anticoag-001
   query: warfarin food interactions
@@ -222,3 +245,4 @@
   category: anticoagulant
   difficulty: hard
   expected_drug_names: [warfarin, coumadin]
+  expected_drug_id: warfarin

--- a/src/mediforme_chatbot_rag/eval/run.py
+++ b/src/mediforme_chatbot_rag/eval/run.py
@@ -1,8 +1,9 @@
 """검색 성능 평가 러너
 
 - queries.yaml + FAISS 인덱스 로드 → 각 쿼리 검색 → Recall@K · MRR · Latency 집계
-- 언어별(ko/en) 분할 점수 출력
-- stdout 표 + 마크다운 리포트(파일) 동시 출력
+- 언어 / 카테고리 / 난이도별 분할 점수 출력
+- --use-drug-id-filter 옵션으로 정규화 검색 모드 측정
+- 실패 쿼리(Recall@10 == 0) 자동 추출 + 리포트 별도 섹션
 """
 
 from __future__ import annotations
@@ -19,12 +20,13 @@ import yaml
 from mediforme_chatbot_rag.eval.metrics import recall_at_k, reciprocal_rank
 from mediforme_chatbot_rag.ingestion.embedder import Embedder
 from mediforme_chatbot_rag.ingestion.index import FaissIndex
+from mediforme_chatbot_rag.services.retrieval import RetrievalService
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="mediforme_chatbot_rag.eval.run",
-        description="검색 성능 평가 — Recall@K · MRR · Latency · 언어별 분할",
+        description="검색 성능 평가 — Recall@K · MRR · Latency · 분할 점수",
     )
     parser.add_argument("--queries", type=Path, required=True, help="queries.yaml 경로")
     parser.add_argument("--index", type=Path, required=True, help="FAISS 인덱스 디렉터리")
@@ -34,6 +36,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         default=Path("data/eval/results.md"),
         help="마크다운 리포트 출력 경로",
+    )
+    parser.add_argument(
+        "--use-drug-id-filter",
+        action="store_true",
+        help="expected_drug_id 가 있는 쿼리는 drug_id 필터를 적용해 검색",
     )
     return parser.parse_args(argv)
 
@@ -45,15 +52,60 @@ def _load_queries(path: Path) -> list[dict[str, Any]]:
     return raw
 
 
-def _percentile(values: list[float], p: float) -> float:
-    if not values:
-        return 0.0
-    sorted_vals = sorted(values)
-    idx = min(len(sorted_vals) - 1, round(p * (len(sorted_vals) - 1)))
-    return sorted_vals[idx]
+def _evaluate_query(
+    query: dict[str, Any],
+    *,
+    service: RetrievalService,
+    top_k: int,
+    use_drug_id_filter: bool,
+) -> dict[str, Any]:
+    """
+    쿼리 1개를 실행하고 결과 dict 를 돌려준다
+    """
+    drug_id = query.get("expected_drug_id") if use_drug_id_filter else None
+
+    start = time.perf_counter()
+    chunks_with_scores = service.retrieve(
+        query["query"],
+        top_k=top_k,
+        drug_id=drug_id,
+    )
+    latency_ms = (time.perf_counter() - start) * 1000.0
+
+    ranked = [c for c, _ in chunks_with_scores]
+    expected_names = query["expected_drug_names"]
+    expected_sections = query.get("expected_sections")
+
+    r5 = recall_at_k(
+        ranked,
+        expected_drug_names=expected_names,
+        expected_sections=expected_sections,
+        k=5,
+    )
+    r10 = recall_at_k(
+        ranked,
+        expected_drug_names=expected_names,
+        expected_sections=expected_sections,
+        k=10,
+    )
+    rr = reciprocal_rank(
+        ranked,
+        expected_drug_names=expected_names,
+        expected_sections=expected_sections,
+    )
+
+    return {
+        "query": query,
+        "ranked": ranked,
+        "r5": r5,
+        "r10": r10,
+        "rr": rr,
+        "latency_ms": latency_ms,
+        "drug_id_used": drug_id,
+    }
 
 
-def _format_split_row(label: str, items: list[dict[str, float]]) -> str:
+def _format_split_row(label: str, items: list[dict[str, Any]]) -> str:
     if not items:
         return f"| {label} | 0 | - | - | - |"
     n = len(items)
@@ -63,27 +115,86 @@ def _format_split_row(label: str, items: list[dict[str, float]]) -> str:
     return f"| {label} | {n} | {avg_r5:.3f} | {avg_r10:.3f} | {avg_mrr:.3f} |"
 
 
-def _build_report(
-    results_by_lang: dict[str, list[dict[str, float]]],
-    latencies_ms: list[float],
-    *,
-    top_k: int,
-) -> str:
-    all_results = [item for items in results_by_lang.values() for item in items]
+def _build_split_table(
+    title: str,
+    groups: dict[str, list[dict[str, Any]]],
+) -> list[str]:
+    all_items = [item for items in groups.values() for item in items]
     lines = [
-        "# 검색 성능 평가 결과",
-        "",
-        f"top-K = {top_k}, N = {len(all_results)}",
-        "",
-        "## 지표",
+        f"### {title}",
         "",
         "| 분할 | N | Recall@5 | Recall@10 | MRR |",
         "|---|---|---|---|---|",
     ]
-    for lang in sorted(results_by_lang.keys()):
-        lines.append(_format_split_row(lang, results_by_lang[lang]))
-    lines.append(_format_split_row("**전체**", all_results))
+    for key in sorted(groups.keys()):
+        lines.append(_format_split_row(key, groups[key]))
+    lines.append(_format_split_row("**전체**", all_items))
     lines.append("")
+    return lines
+
+
+def _failure_entries(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Recall@10 == 0 인 쿼리만 골라 반환
+    """
+    return [r for r in results if r["r10"] == 0.0]
+
+
+def _build_failure_section(failures: list[dict[str, Any]]) -> list[str]:
+    if not failures:
+        return ["## 실패 케이스 (Recall@10 == 0)", "", "(없음)", ""]
+    lines = ["## 실패 케이스 (Recall@10 == 0)", ""]
+    for r in failures:
+        q = r["query"]
+        lines.append(f"### {q['id']} — `{q['query']}`")
+        lines.append(f"- expected_drug_names: {q['expected_drug_names']}")
+        if r["drug_id_used"]:
+            lines.append(f"- drug_id 필터 적용: `{r['drug_id_used']}`")
+        lines.append("- top-3 결과:")
+        for i, chunk in enumerate(r["ranked"][:3], start=1):
+            lines.append(f"  {i}. `{chunk.drug_name}` / `{chunk.section}` (source={chunk.source})")
+        lines.append("")
+    return lines
+
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    idx = min(len(sorted_vals) - 1, round(p * (len(sorted_vals) - 1)))
+    return sorted_vals[idx]
+
+
+def _build_report(
+    results: list[dict[str, Any]],
+    latencies_ms: list[float],
+    *,
+    top_k: int,
+    use_drug_id_filter: bool,
+) -> str:
+    filter_label = "ON" if use_drug_id_filter else "OFF"
+    lines = [
+        "# 검색 성능 평가 결과",
+        "",
+        f"top-K = {top_k}, N = {len(results)}, drug_id 필터 = {filter_label}",
+        "",
+        "## 지표",
+        "",
+    ]
+
+    by_lang: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_difficulty: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in results:
+        q = r["query"]
+        by_lang[q.get("language", "unknown")].append(r)
+        by_category[q.get("category", "unknown")].append(r)
+        by_difficulty[q.get("difficulty", "unknown")].append(r)
+
+    lines.extend(_build_split_table("언어별", dict(by_lang)))
+    lines.extend(_build_split_table("카테고리별", dict(by_category)))
+    lines.extend(_build_split_table("난이도별", dict(by_difficulty)))
+
     lines.append("## Latency (검색 단일 호출)")
     lines.append("")
     if latencies_ms:
@@ -91,6 +202,9 @@ def _build_report(
         p95 = _percentile(latencies_ms, 0.95)
         lines.append(f"- p50: {p50:.1f} ms")
         lines.append(f"- p95: {p95:.1f} ms")
+    lines.append("")
+
+    lines.extend(_build_failure_section(_failure_entries(results)))
     return "\n".join(lines)
 
 
@@ -104,42 +218,26 @@ def main(argv: list[str] | None = None) -> int:
     # 모델 사전 로드 — Latency 측정에서 첫 호출 모델 로딩 시간 제거
     embedder.embed(["warmup"])
 
-    results_by_lang: dict[str, list[dict[str, float]]] = defaultdict(list)
+    service = RetrievalService(embedder=embedder, index=index)
+
+    results: list[dict[str, Any]] = []
     latencies_ms: list[float] = []
-
     for q in queries:
-        query_text = q["query"]
-        expected_names = q["expected_drug_names"]
-        expected_sections = q.get("expected_sections")
-        language = q.get("language", "unknown")
-
-        start = time.perf_counter()
-        query_emb = embedder.embed([query_text])[0]
-        chunks_with_scores = index.search(query_emb, top_k=args.top_k)
-        latency_ms = (time.perf_counter() - start) * 1000.0
-        latencies_ms.append(latency_ms)
-
-        ranked = [c for c, _ in chunks_with_scores]
-        r5 = recall_at_k(
-            ranked,
-            expected_drug_names=expected_names,
-            expected_sections=expected_sections,
-            k=5,
+        result = _evaluate_query(
+            q,
+            service=service,
+            top_k=args.top_k,
+            use_drug_id_filter=args.use_drug_id_filter,
         )
-        r10 = recall_at_k(
-            ranked,
-            expected_drug_names=expected_names,
-            expected_sections=expected_sections,
-            k=10,
-        )
-        rr = reciprocal_rank(
-            ranked,
-            expected_drug_names=expected_names,
-            expected_sections=expected_sections,
-        )
-        results_by_lang[language].append({"r5": r5, "r10": r10, "rr": rr, "latency_ms": latency_ms})
+        results.append(result)
+        latencies_ms.append(result["latency_ms"])
 
-    report = _build_report(results_by_lang, latencies_ms, top_k=args.top_k)
+    report = _build_report(
+        results,
+        latencies_ms,
+        top_k=args.top_k,
+        use_drug_id_filter=args.use_drug_id_filter,
+    )
     print(report)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(report + "\n", encoding="utf-8")

--- a/tests/eval/test_run.py
+++ b/tests/eval/test_run.py
@@ -1,0 +1,140 @@
+"""평가 러너 보조 함수 단위 테스트
+
+- 실패 케이스 추출, 분할 표 포맷, 실패 섹션 마크다운 동작 검증
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mediforme_chatbot_rag.eval.run import (
+    _build_failure_section,
+    _build_split_table,
+    _failure_entries,
+    _format_split_row,
+    _percentile,
+)
+from mediforme_chatbot_rag.ingestion.chunker import Chunk
+
+
+def _result(
+    *,
+    qid: str,
+    r5: float,
+    r10: float,
+    rr: float,
+    drug_id: str | None = None,
+    ranked: list[Chunk] | None = None,
+    expected_drug_names: list[str] | None = None,
+    query_text: str = "test",
+) -> dict[str, Any]:
+    return {
+        "query": {
+            "id": qid,
+            "query": query_text,
+            "expected_drug_names": expected_drug_names or ["test"],
+        },
+        "ranked": ranked or [],
+        "r5": r5,
+        "r10": r10,
+        "rr": rr,
+        "latency_ms": 12.0,
+        "drug_id_used": drug_id,
+    }
+
+
+def test_failure_entries_filters_by_r10_zero() -> None:
+    results = [
+        _result(qid="a", r5=0, r10=1, rr=0.5),
+        _result(qid="b", r5=0, r10=0, rr=0),
+        _result(qid="c", r5=1, r10=1, rr=1),
+        _result(qid="d", r5=0, r10=0, rr=0),
+    ]
+
+    failures = _failure_entries(results)
+
+    assert [f["query"]["id"] for f in failures] == ["b", "d"]
+
+
+def test_failure_entries_returns_empty_when_no_failures() -> None:
+    results = [_result(qid="a", r5=1, r10=1, rr=1)]
+
+    assert _failure_entries(results) == []
+
+
+def test_format_split_row_handles_empty_group() -> None:
+    row = _format_split_row("ko", [])
+
+    assert "0" in row
+    assert "-" in row
+
+
+def test_format_split_row_averages_metrics() -> None:
+    items = [
+        _result(qid="a", r5=1.0, r10=1.0, rr=1.0),
+        _result(qid="b", r5=0.0, r10=1.0, rr=0.5),
+    ]
+
+    row = _format_split_row("ko", items)
+
+    assert "ko" in row
+    assert "2" in row
+    assert "0.500" in row  # avg r5
+    assert "1.000" in row  # avg r10
+    assert "0.750" in row  # avg rr
+
+
+def test_build_split_table_includes_all_groups_and_overall() -> None:
+    groups = {
+        "ko": [_result(qid="k1", r5=0, r10=1, rr=0.5)],
+        "en": [_result(qid="e1", r5=1, r10=1, rr=1)],
+    }
+
+    lines = _build_split_table("언어별", groups)
+
+    assert "### 언어별" in lines
+    joined = "\n".join(lines)
+    assert "| ko |" in joined
+    assert "| en |" in joined
+    assert "**전체**" in joined
+
+
+def test_build_failure_section_no_failures() -> None:
+    lines = _build_failure_section([])
+
+    joined = "\n".join(lines)
+    assert "(없음)" in joined
+
+
+def test_build_failure_section_includes_query_metadata() -> None:
+    chunk = Chunk(text="t", section="warnings", drug_name="ASPIRIN", source="fda_label")
+    failures = [
+        _result(
+            qid="ko-pain-001",
+            r5=0,
+            r10=0,
+            rr=0,
+            drug_id="타이레놀",
+            ranked=[chunk],
+            expected_drug_names=["타이레놀"],
+            query_text="타이레놀 부작용",
+        )
+    ]
+
+    lines = _build_failure_section(failures)
+    joined = "\n".join(lines)
+
+    assert "ko-pain-001" in joined
+    assert "타이레놀 부작용" in joined
+    assert "['타이레놀']" in joined or "['타이레놀']" in joined
+    assert "drug_id 필터 적용" in joined
+    assert "ASPIRIN" in joined
+    assert "warnings" in joined
+
+
+def test_percentile_basics() -> None:
+    values = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    assert _percentile(values, 0.0) == 1.0
+    assert _percentile(values, 1.0) == 5.0
+    assert _percentile([], 0.5) == 0.0


### PR DESCRIPTION
## 요약
이슈 #21 의 평가 러너 보강을 마쳤습니다. 1차 평가에서 한국어/영어 점수 차이는 확인됐는데, 어느 영역에서 어떤 식으로 무너지는지 더 구체적으로 파악하는 게 우선이라 판단했습니다. 이번 변경으로 카테고리·난이도 분할, drug_id 필터 ON/OFF 비교, 실패 케이스 자동 추출까지 한 번의 실행으로 같이 볼 수 있게 되었습니다.

## 주요 변경
- **drug_id 필터 모드** — \`--use-drug-id-filter\` 플래그. queries.yaml 의 expected_drug_id 가 있으면 RetrievalService.retrieve 의 drug_id 인자로 전달
- **카테고리·난이도 분할 점수** — 기존 언어 분할에 추가, 같은 표 형식으로 카테고리·난이도까지 출력
- **실패 케이스 자동 추출** — Recall@10 == 0 인 쿼리만 모아서 별도 마크다운 섹션. 쿼리 텍스트 / expected_drug_names / 적용된 drug_id 필터 / top-3 실제 결과 함께 출력
- **러너 RetrievalService 사용으로 리팩터** — drug_id 필터 처리를 프로덕션 코드와 동일 경로로 통일
- **queries.yaml** — 30개 항목 중 단일 약물 정답이 명확한 22개에 expected_drug_id 추가, 의도형 8개는 비워둠

## 구현 메모
- **expected_drug_id 가 비어 있는 쿼리**: 필터 ON 모드에서도 자유 검색으로 처리합니다. 인텐트 추출 실패 시 폴백 동작을 모사한 형태입니다.
- **러너 출력 경로**: 기본은 data/eval/results.md 그대로. 두 모드 결과를 보존하려면 \`--output\` 으로 다른 파일에 저장하면 됩니다 (예: results-no-filter.md / results-with-filter.md).
- **테스트 전략**: 러너 전체 end-to-end 는 실 모델 / 인덱스 의존성이 커서 보조 함수(_failure_entries, _format_split_row, _build_split_table, _build_failure_section, _percentile) 의 단위 테스트로 커버했습니다. 실측은 머지 후 별도로 수행.

## 테스트 결과
- pytest 83개 통과 (러너 헬퍼 8 + 메트릭 11 + 기존 64), integration 4 제외
- mypy / ruff 통과

## 다음
머지 후 별도로 평가 OFF / ON 각 1회 실행 → wiki 의 검증 페이지에 분할 결과 표 + 실패 케이스 분석 추가 예정.

Closes #21