### PR TITLE
feat(embedder): 임베딩 모델 BGE-M3 로 교체 (#23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,9 @@ DATABASE_URL=postgresql://mediforme:mediforme@localhost:5432/mediforme_rag
 APP_ENV=local
 LOG_LEVEL=INFO
 
-# --- 임베딩 모델 (SBERT 다국어) ---
-EMBEDDING_MODEL_NAME=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
-EMBEDDING_DIMENSIONS=768
+# --- 임베딩 모델 (다국어) ---
+EMBEDDING_MODEL_NAME=BAAI/bge-m3
+EMBEDDING_DIMENSIONS=1024
 EMBEDDING_BATCH_SIZE=32
 
 # --- FAISS 인덱스 ---

--- a/src/mediforme_chatbot_rag/core/config.py
+++ b/src/mediforme_chatbot_rag/core/config.py
@@ -22,8 +22,8 @@ class Settings(BaseSettings):
     mfds_api_key: str = ""
     mfds_base_url: str = "https://apis.data.go.kr/1471000/DrbEasyDrugInfoService"
 
-    embedding_model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
-    embedding_dimensions: int = 768
+    embedding_model_name: str = "BAAI/bge-m3"
+    embedding_dimensions: int = 1024
     embedding_batch_size: int = 32
 
     index_dir: str = "data/index"


### PR DESCRIPTION
## 요약
이슈 #23 의 임베딩 모델 교체를 적용했습니다. 평가 분할 결과를 보면서 다국어 임베딩 후보 비교가 필요한 시점이라 판단해 BAAI/bge-m3 로 갈아끼웁니다. 머지 후 인덱스 재빌드 + 같은 쿼리 셋으로 재측정해서 wiki 검증 페이지에 비교 표를 추가할 예정입니다.

## 주요 변경
- Settings.embedding_model_name: \`sentence-transformers/paraphrase-multilingual-mpnet-base-v2\` → \`BAAI/bge-m3\`
- Settings.embedding_dimensions: 768 → 1024
- .env.example 의 EMBEDDING_MODEL_NAME / EMBEDDING_DIMENSIONS 갱신, 섹션 헤딩도 "다국어" 로 정리

## 구현 메모
- **인덱스 호환성 깨짐**: 차원이 768 → 1024 라 기존 data/index/ 와 호환 불가. 머지 후 인덱스 재빌드가 필요하고, 베이스라인 비교용으로 기존 인덱스는 data/index_mpnet/ 로 이동해 두려 합니다 (gitignored 데이터).
- **모델 다운로드**: BGE-M3 가중치는 ~2.3GB 라 첫 실행 시 다운로드 시간이 mpnet 보다 깁니다. 이후엔 캐시.
- **테스트는 영향 없음**: 단위 테스트는 fake model 주입 패턴이라 모델 변경과 독립. integration 테스트는 실 호출 시 새 모델로 자동 전환.
- **운영 호환**: backend_medi 통합 전이라 외부 영향 없음.

## 테스트 결과
- pytest 83개 통과
- mypy / ruff 통과

## 다음 (별도 작업)
- 인덱스 백업(data/index_mpnet) + BGE-M3 로 재빌드
- 평가 OFF / ON 두 모드 재측정
- wiki 의 검증 페이지에 모델 전후 비교 표 추가

Closes #23