### PR TITLE
fix(embedder): BGE-M3 max_seq_length 캡으로 attention OOM 회피 (#25)

### DIFF
--- a/src/mediforme_chatbot_rag/ingestion/embedder.py
+++ b/src/mediforme_chatbot_rag/ingestion/embedder.py
@@ -73,7 +73,14 @@ class Embedder:
         return model
 
 
+_MAX_SEQ_LENGTH_CAP = 1024
+
+
 def _load_sentence_transformer(model_name: str) -> SentenceTransformer:
     from sentence_transformers import SentenceTransformer
 
-    return SentenceTransformer(model_name)  # type: ignore[no-any-return]
+    model = SentenceTransformer(model_name)
+    # BGE-M3 처럼 default max_seq_length 가 8192 인 모델은 attention 단계에서
+    # seq² 비례로 OOM 이 나기 쉬워 합리적인 값으로 캡
+    model.max_seq_length = min(model.max_seq_length, _MAX_SEQ_LENGTH_CAP)
+    return model  # type: ignore[no-any-return]


### PR DESCRIPTION
## 요약
이슈 #25 의 BGE-M3 OOM 버그를 고쳤습니다. 임베더 로더에서 max_seq_length 를 1024 로 캡 씌워 attention buffer 가 비현실적으로 커지는 상황을 피합니다. 청크가 토큰 환산 500~800 정도라 1024 면 정보 손실 없이 충분히 처리됩니다.

## 주요 변경
- \`_load_sentence_transformer\` 가 SentenceTransformer 로드 직후 \`max_seq_length = min(model.max_seq_length, 1024)\` 적용
- 모듈 상수 \`_MAX_SEQ_LENGTH_CAP = 1024\` 추가

## 구현 메모
- **왜 1024 인가**: 청커의 MAX_CHUNK_CHARS 가 2000 이라 토큰화 시 보통 500~800 토큰. 여유분 포함해 1024 면 잘림 거의 없음. 더 줄이면 일부 긴 청크 끝이 잘릴 위험.
- **mpnet 영향 없음**: mpnet 의 default max_seq_length 가 128 이라 min(128, 1024) = 128 그대로. 회귀 없음.
- **검증**: BGE-M3 로 FDA 1개 + MFDS 1개 스모크 인덱스 빌드 성공 (19 청크, 18.4초). 이전엔 첫 batch 에서 OOM.

## 테스트 결과
- pytest 83개 그대로 통과 (단위 테스트는 fake model 주입이라 영향 없음)
- 실 BGE-M3 로 스모크 ingest 성공
- mypy / ruff 통과

Closes #25