### PR TITLE
feat(chunker): 청크 텍스트에 약 이름 헤더 prepend (#27)

### DIFF
--- a/src/mediforme_chatbot_rag/ingestion/chunker.py
+++ b/src/mediforme_chatbot_rag/ingestion/chunker.py
@@ -43,22 +43,45 @@ def chunk_label(label: _LabelLike, *, source: str = "fda_label") -> list[Chunk]:
     라벨의 섹션을 검색 단위 청크 리스트로 변환
 
     - source 는 청크의 출처 식별자 (예: fda_label / mfds_label)
+    - 청크 텍스트 첫 줄에 약 이름 헤더를 prepend 해 의미 매칭 표면적을 넓힘
     """
+    header = _build_header(label)
+    body_max = max(MIN_CHUNK_CHARS, MAX_CHUNK_CHARS - len(header) - 2)
     chunks: list[Chunk] = []
     for section, parts in label.sections.items():
         text = "\n".join(part.strip() for part in parts if part.strip())
         if len(text) < MIN_CHUNK_CHARS:
             continue
-        for piece in _split_if_too_long(text, MAX_CHUNK_CHARS):
+        for piece in _split_if_too_long(text, body_max):
             chunks.append(
                 Chunk(
-                    text=piece,
+                    text=f"{header}\n\n{piece}",
                     section=section,
                     drug_name=label.drug_name,
                     source=source,
                 )
             )
     return chunks
+
+
+def _build_header(label: _LabelLike) -> str:
+    """
+    drug_name 과 (있으면) brand_name / generic_name 을 합친 헤더 라인 생성
+    """
+    primary = label.drug_name
+    aliases: list[str] = []
+    for attr in ("brand_name", "generic_name"):
+        candidate = getattr(label, attr, "") or ""
+        if not candidate:
+            continue
+        if candidate.lower() == primary.lower():
+            continue
+        if any(candidate.lower() == a.lower() for a in aliases):
+            continue
+        aliases.append(candidate)
+    if aliases:
+        return f"[{primary} / {' / '.join(aliases)}]"
+    return f"[{primary}]"
 
 
 def _split_if_too_long(text: str, max_chars: int) -> list[str]:

--- a/src/mediforme_chatbot_rag/ingestion/fda_fetcher.py
+++ b/src/mediforme_chatbot_rag/ingestion/fda_fetcher.py
@@ -35,6 +35,8 @@ class FdaLabel(BaseModel):
     """openFDA 라벨 1건의 정규화된 표현."""
 
     drug_name: str
+    brand_name: str = ""
+    generic_name: str = ""
     sections: dict[str, list[str]] = Field(default_factory=dict)
     set_id: str
     effective_time: str
@@ -124,6 +126,8 @@ def _to_label(result: dict[str, Any]) -> FdaLabel:
 
     return FdaLabel(
         drug_name=drug_name,
+        brand_name=brand or "",
+        generic_name=generic or "",
         sections=sections,
         set_id=set_id,
         effective_time=effective_time,

--- a/tests/ingestion/test_chunker.py
+++ b/tests/ingestion/test_chunker.py
@@ -93,8 +93,8 @@ def test_empty_parts_are_filtered_out() -> None:
     chunks = chunk_label(label)
 
     assert len(chunks) == 1
-    assert "For temporary relief" in chunks[0].text
-    assert "\n" not in chunks[0].text
+    body = chunks[0].text.split("\n\n", 1)[1]
+    assert body == "For temporary relief of minor aches and headaches due to colds."
 
 
 def test_multi_part_section_is_joined_with_newline() -> None:
@@ -129,6 +129,44 @@ def test_default_source_is_fda_label() -> None:
     chunks = chunk_label(label)
 
     assert all(c.source == "fda_label" for c in chunks)
+
+
+def test_header_uses_only_drug_name_when_no_brand_generic() -> None:
+    label = _label({"warnings": ["Consult a doctor if symptoms persist for more than seven days."]})
+
+    chunks = chunk_label(label)
+
+    assert chunks[0].text.startswith("[TYLENOL]\n\n")
+
+
+def test_header_includes_brand_and_generic_when_distinct() -> None:
+    label = FdaLabel(
+        drug_name="TYLENOL",
+        brand_name="TYLENOL",
+        generic_name="ACETAMINOPHEN",
+        sections={"warnings": ["Consult a doctor if symptoms persist for more than seven days."]},
+        set_id="x",
+        effective_time="y",
+    )
+
+    chunks = chunk_label(label)
+
+    assert chunks[0].text.startswith("[TYLENOL / ACETAMINOPHEN]\n\n")
+
+
+def test_header_skips_alias_equal_to_primary() -> None:
+    label = FdaLabel(
+        drug_name="ASPIRIN",
+        brand_name="aspirin",  # same as drug_name (case-insensitive)
+        generic_name="ASPIRIN",  # same too
+        sections={"warnings": ["Consult a doctor if symptoms persist for more than seven days."]},
+        set_id="x",
+        effective_time="y",
+    )
+
+    chunks = chunk_label(label)
+
+    assert chunks[0].text.startswith("[ASPIRIN]\n\n")
 
 
 def test_drug_name_propagates_to_chunks() -> None:


### PR DESCRIPTION
## 요약
이슈 #27 의 청크 텍스트 구조 변경을 적용했습니다. 모델 비교 결과에서 한국어 brand 매칭이 모델 단일 변경으로 풀리지 않는 영역으로 식별돼, 청크 의미 매칭 표면적을 넓히는 방향으로 갑니다. 청크 텍스트 첫 줄에 약 이름 헤더를 prepend 해, drug_name 자체가 임베딩 벡터에 들어가도록 만듭니다.

## 주요 변경
- **FdaLabel 모델 확장** — brand_name / generic_name 을 별도 필드로 보존 (이전에는 둘 중 하나만 drug_name 으로 fallback)
- **chunker._build_header** — drug_name 외에 brand_name, generic_name 가 있고 서로 다르면 같이 노출 (예: \`[Pain Reliever Extra Strength / acetaminophen]\`)
- **헤더 prepend** — chunk.text 가 \`[{header}]\n\n{body}\` 형태로. body 최대 길이는 (MAX_CHUNK_CHARS − 헤더 길이) 로 계산해 chunk.text 가 MAX_CHUNK_CHARS 를 넘지 않게
- **단위 테스트 갱신** — 기존 1개(empty parts) 갱신 + 헤더 동작 3개 신규 (only drug_name / with brand+generic / 중복 제거)

## 구현 메모
- **MFDS 라벨도 같은 코드 경로**: MfdsLabel 은 brand_name/generic_name 필드가 없어 getattr default "" 가 적용. 결과적으로 헤더는 itemName 만 사용.
- **헤더 길이 영향**: 50자 안팎. body_max 만 적당히 줄여 chunk.text 가 MAX_CHUNK_CHARS 한도를 안 넘기게 처리.
- **MIN_CHUNK_CHARS 적용 시점**: body 텍스트 기준. 헤더 전 길이로 판단해 무의미 섹션이 헤더 덕에 통과되는 일 없게.

## 인덱스 영향 (별도 작업)
청크 텍스트 자체가 바뀌므로 인덱스 재빌드 필수. 머지 후 다음 흐름:
1. data/index 백업 → data/index_no_header (또는 그대로 덮어쓰기 — 베이스라인은 wiki 에 이미 박힘)
2. 동일 시드로 재인덱싱
3. 평가 OFF / ON 두 모드 재측정
4. wiki 의 모델 비교 페이지에 "헤더 prepend 적용 후" 섹션 추가

## 테스트 결과
- pytest 86개 통과 (헤더 관련 신규 3 + 기존 갱신)
- mypy / ruff 통과

Closes #27