### PR TITLE
feat(retrieval): drug_id 필터에 brand·generic alias 매칭 추가

### DIFF
--- a/scripts/backfill_chunk_aliases.py
+++ b/scripts/backfill_chunk_aliases.py
@@ -25,7 +25,7 @@ def parse_aliases(text: str, drug_name: str) -> tuple[str, str, bool]:
         return "", "", True
     prefix = f"{drug_name} / "
     if inner.startswith(prefix):
-        aliases = inner[len(prefix):].split(" / ")
+        aliases = inner[len(prefix) :].split(" / ")
         ok = True
     else:
         parts = inner.split(" / ")

--- a/scripts/backfill_chunk_aliases.py
+++ b/scripts/backfill_chunk_aliases.py
@@ -1,0 +1,67 @@
+"""일회성 백필: 기존 chunks.json 의 text 헤더에서 brand/generic alias 복원
+
+- 기존 인덱스는 Chunk 모델에 brand_name/generic_name 필드가 생기기 전 빌드라
+  메타가 비어 있으나, text 첫 줄 헤더 `[primary / alias1 / alias2]` 에 이름이 보존돼 있음
+- 헤더를 파싱해 alias 를 generic_name/brand_name 필드로 채움 (필터는 세 필드 OR 매칭이라
+  brand/generic 할당 순서는 무관, 이름 집합만 맞으면 정식 재빌드와 동작 동일)
+- text 는 불변이므로 index.faiss 벡터는 그대로 재사용 (재임베딩 없음)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+INDEX_DIR = Path("data/index")
+
+
+def parse_aliases(text: str, drug_name: str) -> tuple[str, str, bool]:
+    first = text.splitlines()[0].strip()
+    if not (first.startswith("[") and first.endswith("]")):
+        return "", "", False  # 헤더 형식 아님
+    inner = first[1:-1]
+    if inner == drug_name:
+        return "", "", True
+    prefix = f"{drug_name} / "
+    if inner.startswith(prefix):
+        aliases = inner[len(prefix):].split(" / ")
+        ok = True
+    else:
+        parts = inner.split(" / ")
+        aliases = parts[1:]
+        ok = bool(parts) and parts[0] == drug_name
+    generic = aliases[0] if aliases else ""
+    brand = " / ".join(aliases[1:]) if len(aliases) > 1 else ""
+    return brand, generic, ok
+
+
+def main() -> int:
+    chunks_path = INDEX_DIR / "chunks.json"
+    data = json.loads(chunks_path.read_text(encoding="utf-8"))
+
+    total = len(data)
+    with_alias = 0
+    mismatches = 0
+    for c in data:
+        brand, generic, ok = parse_aliases(c["text"], c["drug_name"])
+        c["brand_name"] = brand
+        c["generic_name"] = generic
+        if generic or brand:
+            with_alias += 1
+        if not ok:
+            mismatches += 1
+
+    if mismatches:
+        print(f"경고: 헤더-drug_name 불일치 {mismatches}건", file=sys.stderr)
+
+    chunks_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(f"백필 완료: {total} 청크 중 {with_alias} 청크에 alias 채움 (불일치 {mismatches})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mediforme_chatbot_rag/ingestion/chunker.py
+++ b/src/mediforme_chatbot_rag/ingestion/chunker.py
@@ -35,6 +35,8 @@ class Chunk(BaseModel):
     text: str
     section: str
     drug_name: str
+    brand_name: str = ""
+    generic_name: str = ""
     source: str = "fda_label"
 
 
@@ -47,6 +49,8 @@ def chunk_label(label: _LabelLike, *, source: str = "fda_label") -> list[Chunk]:
     """
     header = _build_header(label)
     body_max = max(MIN_CHUNK_CHARS, MAX_CHUNK_CHARS - len(header) - 2)
+    brand = getattr(label, "brand_name", "") or ""
+    generic = getattr(label, "generic_name", "") or ""
     chunks: list[Chunk] = []
     for section, parts in label.sections.items():
         text = "\n".join(part.strip() for part in parts if part.strip())
@@ -58,6 +62,8 @@ def chunk_label(label: _LabelLike, *, source: str = "fda_label") -> list[Chunk]:
                     text=f"{header}\n\n{piece}",
                     section=section,
                     drug_name=label.drug_name,
+                    brand_name=brand,
+                    generic_name=generic,
                     source=source,
                 )
             )

--- a/src/mediforme_chatbot_rag/services/retrieval.py
+++ b/src/mediforme_chatbot_rag/services/retrieval.py
@@ -74,6 +74,9 @@ def _matches_filters(
     drug_id: str | None,
     category: str | None,
 ) -> bool:
-    if drug_id is not None and chunk.drug_name.lower() != drug_id.lower():
-        return False
+    if drug_id is not None:
+        needle = drug_id.lower()
+        candidates = (chunk.drug_name, chunk.brand_name, chunk.generic_name)
+        if not any(needle in c.lower() for c in candidates if c):
+            return False
     return not (category is not None and chunk.section != category)

--- a/tests/services/test_retrieval.py
+++ b/tests/services/test_retrieval.py
@@ -99,6 +99,88 @@ def test_retrieve_drug_id_filter_is_case_insensitive() -> None:
     assert all(chunk.drug_name == "ASPIRIN" for chunk, _ in results)
 
 
+def test_retrieve_drug_id_matches_generic_when_drug_name_is_brand() -> None:
+    """
+    drug_name 이 brand 명("PAIN RELIEVER") 인 청크를 generic("acetaminophen") 으로 검색해도 매칭
+    """
+    index = FaissIndex(dim=4)
+    chunks = [
+        Chunk(
+            text="warning text",
+            section="warnings",
+            drug_name="PAIN RELIEVER EXTRA STRENGTH",
+            brand_name="PAIN RELIEVER EXTRA STRENGTH",
+            generic_name="ACETAMINOPHEN",
+        ),
+    ]
+    embeddings = [[1.0, 0.0, 0.0, 0.0]]
+    index.add(chunks, embeddings)
+
+    service = RetrievalService(
+        embedder=_embedder_with([1.0, 0.0, 0.0, 0.0]),
+        index=index,
+    )
+
+    results = service.retrieve("liver damage", top_k=5, drug_id="acetaminophen")
+
+    assert len(results) == 1
+    assert results[0][0].drug_name == "PAIN RELIEVER EXTRA STRENGTH"
+
+
+def test_retrieve_drug_id_matches_brand_when_drug_name_is_generic() -> None:
+    """
+    drug_name 이 generic("ibuprofen") 인 청크를 brand("ADVIL") 로 검색해도 매칭
+    """
+    index = FaissIndex(dim=4)
+    chunks = [
+        Chunk(
+            text="dosage text",
+            section="dosage",
+            drug_name="ibuprofen",
+            brand_name="ADVIL",
+            generic_name="ibuprofen",
+        ),
+    ]
+    embeddings = [[1.0, 0.0, 0.0, 0.0]]
+    index.add(chunks, embeddings)
+
+    service = RetrievalService(
+        embedder=_embedder_with([1.0, 0.0, 0.0, 0.0]),
+        index=index,
+    )
+
+    results = service.retrieve("kidney", top_k=5, drug_id="advil")
+
+    assert len(results) == 1
+
+
+def test_retrieve_drug_id_filter_excludes_unrelated_chunks() -> None:
+    """
+    drug_id 가 어느 필드와도 매칭 안 되면 결과 비어있어야 함
+    """
+    index = FaissIndex(dim=4)
+    chunks = [
+        Chunk(
+            text="text",
+            section="warnings",
+            drug_name="ASPIRIN",
+            brand_name="ASPIRIN",
+            generic_name="aspirin",
+        ),
+    ]
+    embeddings = [[1.0, 0.0, 0.0, 0.0]]
+    index.add(chunks, embeddings)
+
+    service = RetrievalService(
+        embedder=_embedder_with([1.0, 0.0, 0.0, 0.0]),
+        index=index,
+    )
+
+    results = service.retrieve("query", top_k=5, drug_id="ibuprofen")
+
+    assert results == []
+
+
 def test_retrieve_category_filter_matches_section() -> None:
     service = RetrievalService(
         embedder=_embedder_with([1.0, 0.0, 0.0, 0.0]),


### PR DESCRIPTION
closes #33

## 배경

- drug_id 필터가 `chunk.drug_name` 한 필드만 substring 매칭하고 있었습니다.
- FDA 청크는 drug_name 이 brand 명("Pain Reliever Extra Strength")인 반면 사용자가 보내는 drug_id 는 generic("acetaminophen")인 경우가 많아, ON 모드에서 매칭이 거의 되지 않았습니다 (평가셋 80 기준 R@10 0.125).

## 변경

- Chunk 모델에 `brand_name` / `generic_name` 필드를 추가했습니다 (optional, default `""`).
- chunker 가 label 의 brand/generic 을 청크로 propagate 합니다.
- `_matches_filters` 가 drug_id 를 `drug_name` / `brand_name` / `generic_name` 세 필드에 OR substring 매칭합니다 - 셋 중 하나라도 걸리면 통과합니다.

## 인덱스 반영 방식

- 이번 변경은 메타데이터 필드만 추가하고 청크 text 는 바꾸지 않습니다. 약 이름 헤더(`[brand / generic]`)는 이미 #28 에서 text 에 들어가 있습니다.
- 따라서 풀 재인제스트 대신, 기존 인덱스의 `chunks.json` 헤더를 파싱해 brand/generic 메타만 백필했습니다. text 가 불변이라 `index.faiss` 벡터는 그대로 재사용했고 재임베딩은 생략했습니다.
- 필터는 세 필드 OR 매칭이라, 헤더의 이름 집합을 그대로 채우면 정식 재빌드와 동작이 동일합니다.
- 백필 스크립트: `scripts/backfill_chunk_aliases.py` (일회성 마이그레이션, 향후 정식 재빌드는 ingest CLI 가 올바른 메타를 생성합니다).

## 평가 (N=80, top-K=10)

| 모드 | R@5 | R@10 | MRR |
|---|---|---|---|
| OFF (before/after 동일) | 0.588 | 0.600 | 0.577 |
| ON (before) | 0.125 | 0.125 | 0.125 |
| ON (after) | 0.625 | 0.625 | 0.625 |

- ON 모드 R@10 이 0.125 → 0.625 로 회복됐고, 언어별로는 en 0.784 / ko 0.488 입니다.
- OFF 모드 수치가 동일한 것은 벡터 재사용으로 검색 품질이 보존됐음을 확인해 줍니다.

## 남는 한계

- 한국 brand("타이레놀") ↔ 영어 generic("acetaminophen") cross-lingual 매핑은 alias 사전이 필요하며 Phase 2 별도 이슈로 다룹니다.