### PR TITLE
chore(eval): RAG 구성 ablation 측정·시각화 도구 추가

### DIFF
--- a/scripts/build_variant_index.py
+++ b/scripts/build_variant_index.py
@@ -1,0 +1,97 @@
+"""ablation 비교용 변형 인덱스 빌더
+
+- 기존 data/index/chunks.json 의 코퍼스를 고정하고 모델·헤더만 바꿔 재임베딩
+- 헤더 효과 측정을 위해 --strip-header 로 청크 text 첫 줄 약 이름 헤더 제거
+- OOM/중단 대비로 샤드 단위 임베딩 후 .npy 체크포인트 저장 (재실행 시 이어서)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+from mediforme_chatbot_rag.ingestion.chunker import Chunk
+from mediforme_chatbot_rag.ingestion.embedder import Embedder
+from mediforme_chatbot_rag.ingestion.index import FaissIndex
+
+SRC = Path("data/index/chunks.json")
+
+
+def strip_header(text: str) -> str:
+    parts = text.split("\n\n", 1)
+    if len(parts) == 2 and parts[0].startswith("["):
+        return parts[1]
+    return text
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    ap.add_argument("--dim", type=int, required=True)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--shard", type=int, default=2000)
+    ap.add_argument("--strip-header", action="store_true")
+    ap.add_argument("--checkpoint", type=Path, required=True)
+    args = ap.parse_args()
+
+    data = json.loads(SRC.read_text(encoding="utf-8"))
+    chunks: list[Chunk] = []
+    for c in data:
+        text = strip_header(c["text"]) if args.strip_header else c["text"]
+        chunks.append(
+            Chunk(
+                text=text,
+                section=c["section"],
+                drug_name=c["drug_name"],
+                brand_name=c.get("brand_name", ""),
+                generic_name=c.get("generic_name", ""),
+                source=c.get("source", "fda_label"),
+            )
+        )
+    n = len(chunks)
+    args.checkpoint.mkdir(parents=True, exist_ok=True)
+    embedder = Embedder(model_name=args.model, batch_size=args.batch_size)
+
+    print(
+        f"[build] model={args.model} n={n} shard={args.shard} "
+        f"batch={args.batch_size} strip_header={args.strip_header}",
+        flush=True,
+    )
+    t0 = time.time()
+    for start in range(0, n, args.shard):
+        shard_path = args.checkpoint / f"shard_{start:06d}.npy"
+        if shard_path.exists():
+            print(f"[skip] shard {start} 이미 있음", flush=True)
+            continue
+        texts = [c.text for c in chunks[start : start + args.shard]]
+        vecs = embedder.embed(texts)
+        np.save(shard_path, np.asarray(vecs, dtype=np.float32))
+        done = min(start + args.shard, n)
+        el = time.time() - t0
+        eta = el / done * (n - done) / 60 if done else 0
+        print(
+            f"[shard] {done}/{n} ({100 * done / n:.0f}%) elapsed {el / 60:.1f}min eta {eta:.1f}min",
+            flush=True,
+        )
+
+    print("[assemble] 샤드 로드", flush=True)
+    all_vecs = [
+        np.load(args.checkpoint / f"shard_{start:06d}.npy") for start in range(0, n, args.shard)
+    ]
+    embeddings = np.concatenate(all_vecs, axis=0)
+    if embeddings.shape[0] != n:
+        raise ValueError(f"임베딩 수 불일치: {embeddings.shape[0]} != {n}")
+    index = FaissIndex(dim=args.dim)
+    index.add(chunks, [list(map(float, row)) for row in embeddings])
+    index.save(args.output)
+    print(f"[done] 저장 완료: {args.output} ({len(index)} 청크)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make_charts.py
+++ b/scripts/make_charts.py
@@ -1,0 +1,120 @@
+"""ablation 비교 그래프 생성
+
+- RAG 구성 종합 비교(시드620 · 80쿼리)에서 측정한 수치를 막대그래프로 렌더
+- data/eval/charts/ 에 PNG 3종 저장 (모델·헤더 지표 / 언어별 R@10 / 시드·필터 개선)
+- matplotlib 은 일회성으로 `uv run --with matplotlib python scripts/make_charts.py` 실행
+- 수치는 data/eval/abl-*.md, results-large-*-q80*.md 측정 결과를 옮긴 것
+"""
+
+from pathlib import Path
+
+import matplotlib
+import matplotlib.font_manager as fm
+import numpy as np
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# 한국어 라벨용 폰트 (macOS 기본). 없으면 시스템 기본 폰트로 진행
+_FONT_CANDIDATES = [
+    "/System/Library/Fonts/Supplemental/AppleGothic.ttf",
+    "/System/Library/Fonts/AppleSDGothicNeo.ttc",
+]
+for _font in _FONT_CANDIDATES:
+    if Path(_font).exists():
+        fm.fontManager.addfont(_font)
+        plt.rcParams["font.family"] = fm.FontProperties(fname=_font).get_name()
+        break
+plt.rcParams["axes.unicode_minus"] = False
+
+OUT = Path("data/eval/charts")
+OUT.mkdir(parents=True, exist_ok=True)
+
+configs = ["mpnet\n무헤더", "mpnet\n헤더", "BGE-M3\n무헤더", "BGE-M3\n헤더\n(채택)"]
+R5 = [0.412, 0.438, 0.487, 0.588]
+R10 = [0.500, 0.512, 0.512, 0.600]
+MRR = [0.334, 0.350, 0.423, 0.577]
+EN = [0.676, 0.676, 0.757, 0.784]
+KO = [0.349, 0.372, 0.302, 0.442]
+
+CHOSEN = 3  # index of 채택 구성
+C1, C2, C3 = "#7eb0d5", "#5a8fbf", "#1f5e8b"
+GREEN = "#6aa84f"
+
+
+def label_bars(ax, bars, fmt="%.3f", size=8):
+    for b in bars:
+        h = b.get_height()
+        ax.text(
+            b.get_x() + b.get_width() / 2,
+            h + 0.008,
+            fmt % h,
+            ha="center",
+            va="bottom",
+            fontsize=size,
+        )
+
+
+# 1) 모델·헤더 지표
+fig, ax = plt.subplots(figsize=(9, 5.2))
+x = np.arange(len(configs))
+w = 0.26
+b1 = ax.bar(x - w, R5, w, label="Recall@5", color=C1)
+b2 = ax.bar(x, R10, w, label="Recall@10", color=C2)
+b3 = ax.bar(x + w, MRR, w, label="MRR", color=C3)
+ax.axvspan(CHOSEN - 0.5, CHOSEN + 0.5, color="#fff2cc", alpha=0.6, zorder=0)
+for b in (b1, b2, b3):
+    label_bars(ax, b)
+ax.set_xticks(x)
+ax.set_xticklabels(configs)
+ax.set_ylabel("점수")
+ax.set_ylim(0, 0.7)
+ax.set_title("모델 × 헤더 구성별 검색 성능 (OFF 모드 · 시드620 · 80쿼리)")  # noqa: RUF001
+ax.legend(loc="upper left")
+ax.grid(axis="y", alpha=0.3)
+fig.tight_layout()
+fig.savefig(OUT / "abl_metrics.png", dpi=150)
+plt.close(fig)
+
+# 2) 언어별 R@10
+fig, ax = plt.subplots(figsize=(9, 5.2))
+w = 0.34
+b1 = ax.bar(x - w / 2, EN, w, label="영어 (en, 37)", color="#4c72b0")
+b2 = ax.bar(x + w / 2, KO, w, label="한국어 (ko, 43)", color="#dd8452")
+ax.axvspan(CHOSEN - 0.5, CHOSEN + 0.5, color="#fff2cc", alpha=0.6, zorder=0)
+for b in (b1, b2):
+    label_bars(ax, b)
+ax.set_xticks(x)
+ax.set_xticklabels(configs)
+ax.set_ylabel("Recall@10")
+ax.set_ylim(0, 0.9)
+ax.set_title("언어별 Recall@10 — 조합에서 한국어가 회복 (OFF 모드)")
+ax.legend(loc="upper left")
+ax.grid(axis="y", alpha=0.3)
+fig.tight_layout()
+fig.savefig(OUT / "abl_lang.png", dpi=150)
+plt.close(fig)
+
+# 3) 시드·필터 단일 축 개선 (before/after)
+fig, ax = plt.subplots(figsize=(7.5, 5.0))
+groups = ["시드 확장\n(OFF R@10)", "drug_id 필터\n(ON R@10)"]
+before = [0.425, 0.125]
+after = [0.600, 0.625]
+gx = np.arange(len(groups))
+w = 0.34
+b1 = ax.bar(gx - w / 2, before, w, label="개선 전", color="#bdbdbd")
+b2 = ax.bar(gx + w / 2, after, w, label="개선 후", color=GREEN)
+for b in (b1, b2):
+    label_bars(ax, b)
+ax.set_xticks(gx)
+ax.set_xticklabels(groups)
+ax.set_ylabel("점수")
+ax.set_ylim(0, 0.75)
+ax.set_title("시드 확장·필터 개선 효과 (채택 구성)")
+ax.legend(loc="upper left")
+ax.grid(axis="y", alpha=0.3)
+fig.tight_layout()
+fig.savefig(OUT / "abl_decision.png", dpi=150)
+plt.close(fig)
+
+print("saved:", *[str(p) for p in sorted(OUT.glob("*.png"))], sep="\n")


### PR DESCRIPTION
closes #35

## 변경

여러 검색 구성을 동일 조건(시드620 코퍼스 · 80쿼리)에서 다시 측정하고 시각화하기 위한 도구 2종을 추가합니다.

- scripts/build_variant_index.py — 운영 인덱스(data/index)의 청크 코퍼스를 그대로 고정한 채 모델·헤더만 바꿔 재임베딩합니다. 헤더 효과 측정을 위해 청크 텍스트의 약 이름 헤더를 떼는 옵션(--strip-header)을 두었고, 재임베딩 중 OOM 으로 중단돼도 이어서 진행할 수 있도록 샤드 단위 .npy 체크포인트로 중간 저장합니다.
- scripts/make_charts.py — 비교 결과를 막대그래프 3종(모델·헤더 지표 / 언어별 R@10 / 시드·필터 개선)으로 렌더합니다. matplotlib 은 일회성으로 `uv run --with matplotlib` 로 실행하며 프로젝트 의존성은 건드리지 않습니다.

## 측정 결과

동일 조건에서 다시 측정한 결과, 채택 구성(BGE-M3 + 헤더 + 시드620 + brand·generic alias 필터)이 자유 검색(OFF) 전 지표에서 최고임을 확인했습니다. 모델·헤더는 단독으로는 효과가 제한적이지만 함께 적용할 때 한국어와 영어가 동시에 회복되는 시너지를 보입니다. 수치와 그래프는 wiki [RAG 구성 종합 비교](https://github.com/medi4me/mediforme-chatbot-rag/wiki/RAG-구성-종합-비교) 페이지에 정리했습니다.

## 비고

두 스크립트는 ablation 측정용 보조 도구입니다. 측정 산출물(변형 인덱스, 평가 결과 md, 차트 png)은 data/ 관행대로 커밋하지 않습니다.