### PR TITLE
fix(retrieval): drug_id 필터 시 scoped 검색으로 후보 누락 방지

### DIFF
--- a/src/mediforme_chatbot_rag/services/retrieval.py
+++ b/src/mediforme_chatbot_rag/services/retrieval.py
@@ -42,7 +42,14 @@ class RetrievalService:
             return []
 
         query_embedding = self._embedder.embed([query])[0]
-        candidates = self._index.search(query_embedding, top_k * _OVERSAMPLE_FACTOR)
+        # 필터가 있으면 후보를 인덱스 전체로 확장해 해당 약·섹션 청크가 좁은 oversample
+        # 창 밖으로 밀려 빈 결과가 되는 문제를 피함 (filter-then-rank). IndexFlatIP 는
+        # 어차피 전수 계산이라 후보 수를 키워도 비용 차이는 미미하다
+        if drug_id is not None or category is not None:
+            search_k = len(self._index)
+        else:
+            search_k = top_k * _OVERSAMPLE_FACTOR
+        candidates = self._index.search(query_embedding, search_k)
 
         filtered = [
             (chunk, score)

--- a/tests/services/test_retrieval.py
+++ b/tests/services/test_retrieval.py
@@ -214,3 +214,27 @@ def test_retrieve_filter_with_no_match_returns_empty() -> None:
     )
 
     assert service.retrieve("query", top_k=5, drug_id="NOT_EXIST") == []
+
+
+def test_retrieve_drug_id_finds_low_similarity_chunk_outside_oversample_window() -> None:
+    """
+    drug_id 대상 청크가 유사도 낮아 oversample 창 밖이어도 필터로 반환되어야 함
+    (post-filter 가 좁은 후보 창에 걸려 빈 결과가 되던 문제 회귀 방지)
+    """
+    index = FaissIndex(dim=4)
+    # 쿼리([1,0,0,0])에 매우 가까운 ASPIRIN 청크 6개 + 유사도 0 인 TYLENOL 청크 1개
+    chunks = [Chunk(text=f"aspirin {i}", section="warnings", drug_name="ASPIRIN") for i in range(6)]
+    chunks.append(Chunk(text="tylenol", section="indications", drug_name="TYLENOL"))
+    embeddings = [[1.0, 0.0, 0.0, 0.0]] * 6 + [[0.0, 0.0, 0.0, 1.0]]
+    index.add(chunks, embeddings)
+
+    service = RetrievalService(
+        embedder=_embedder_with([1.0, 0.0, 0.0, 0.0]),
+        index=index,
+    )
+
+    # top_k=1 → 기존 oversample(5) 창에는 ASPIRIN 만 들어와 TYLENOL 이 누락되던 케이스
+    results = service.retrieve("pain", top_k=1, drug_id="tylenol")
+
+    assert len(results) == 1
+    assert results[0][0].drug_name == "TYLENOL"


### PR DESCRIPTION
closes #37

## 문제

drug_id 필터가 "쿼리 유사도로 top-(k×5) 후보를 뽑은 뒤 → 필터" 순서라, 해당 약 청크가 좁은 oversample 창 밖에 있으면 필터 후 결과가 비었습니다. 한국어 질의 ↔ 영어 라벨처럼 cross-lingual 이거나 약 청크 수가 적을 때 자주 발생합니다.

실측: 인덱스에 acetaminophen 청크가 30개 있는데도 "타이레놀은 어떤 증상에 먹나요" 질의는 top_k=20(후보 100)으로도 0건이었습니다.

## 변경

drug_id 또는 category 필터가 있으면 검색 후보를 인덱스 전체로 확장해 필터가 모든 청크를 보게 한 뒤 top_k 만 자릅니다 (filter-then-rank). IndexFlatIP 는 어차피 전수 계산이라 비용 영향은 미미합니다.

## 검증

수정 후 같은 질의에서:
- acetaminophen → 5건 (top section=indications_and_usage)
- ibuprofen → 5건, aspirin → 5건, semaglutide → 5건
- 단위 테스트 추가(유사도 낮아 oversample 창 밖인 대상 청크도 필터로 반환되는지) — 전체 11개 통과