### PR TITLE
chore(docker): RAG 서비스 로컬 docker-compose 구동

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# 빌드 컨텍스트에서 제외 — 인덱스·모델·캐시는 런타임에 볼륨으로 마운트
+.git
+.github
+.venv
+.idea
+.pytest_cache
+.ruff_cache
+.mypy_cache
+__pycache__
+**/__pycache__
+*.pyc
+
+# 데이터·로그 (인덱스는 compose 볼륨으로 주입)
+data/
+logs/
+
+# 개발 전용
+tests/
+scripts/
+.env
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ USER app
 
 EXPOSE 8000
 
+HEALTHCHECK --interval=15s --timeout=5s --start-period=120s --retries=10 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/healthz', timeout=3).status == 200 else 1)"
+
 CMD ["uvicorn", "mediforme_chatbot_rag.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,22 @@
 services:
-  db:
-    image: pgvector/pgvector:pg16
-    environment:
-      POSTGRES_USER: mediforme
-      POSTGRES_PASSWORD: mediforme
-      POSTGRES_DB: mediforme_rag
-    ports:
-      - "5432:5432"
-    volumes:
-      - db-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U mediforme -d mediforme_rag"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
-  app:
+  rag:
     build: .
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      DATABASE_URL: postgresql://mediforme:mediforme@db:5432/mediforme_rag
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
-      APP_ENV: local
+    image: mediforme-chatbot-rag:local
     ports:
       - "8000:8000"
-
-volumes:
-  db-data:
+    environment:
+      EMBEDDING_MODEL_NAME: BAAI/bge-m3
+      EMBEDDING_DIMENSIONS: "1024"
+      INDEX_DIR: data/index
+      HF_HOME: /home/app/.cache/huggingface
+    volumes:
+      # FAISS 인덱스 — 이미지에 베이크하지 않고 마운트 (로컬에선 재빌드 없이 교체 가능)
+      - ./data/index:/app/data/index:ro
+      # BGE-M3 모델 — 호스트 HuggingFace 캐시를 재사용해 재다운로드(~2GB) 회피
+      - ${HOME}/.cache/huggingface:/home/app/.cache/huggingface
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/healthz', timeout=3).status == 200 else 1)"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s   # BGE-M3 로드(캐시에서)·인덱스 로드 여유


### PR DESCRIPTION
closes #39

C-6(백엔드 RAG 통합)이 머지됐지만 검색 서비스가 떠 있지 않으면 백엔드는 항상 앵커링 폴백입니다. 1단계로 로컬 docker-compose 로 검색 서비스를 띄워 RAG 가 실제로 동작하게 합니다.

## 변경

- `Dockerfile` — HEALTHCHECK 추가(/healthz)
- `.dockerignore` 추가 — 158MB 인덱스·캐시를 빌드 컨텍스트에서 제외
- `docker-compose.yml` — RAG 서비스 중심으로 정리
  - 인덱스(`./data/index`)·HF 캐시(BGE-M3) 볼륨 마운트 → 이미지에 베이크 안 하고 재다운로드(~2GB) 회피
  - 미사용 pgvector(db) 제거 (스택은 FAISS)
  - 헬스체크 + 모델·인덱스 로드 여유(start_period)

## 검증 (로컬)

`docker compose up` 후:
- `/healthz` 200
- `/retrieve` — acetaminophen·ibuprofen(OTC)·semaglutide 모두 5청크 반환(인덱스 마운트 + 모델 캐시 + scoped retrieval 동작 확인)

## 다음 (별도)

클라우드 호스팅 시에는 인덱스·모델을 이미지에 베이크(또는 영구 볼륨)하고 `RAG_SERVICE_URL` 을 운영값으로. 선행: scoped retrieval PR #38(머지됨).